### PR TITLE
Add TTL management to all Soroban persistent and instance storage

### DIFF
--- a/contracts/publisher-verification/src/lib.rs
+++ b/contracts/publisher-verification/src/lib.rs
@@ -74,6 +74,11 @@ pub enum DataKey {
 // Contract
 // ============================================================
 
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
+const INSTANCE_BUMP_AMOUNT: u32 = 86_400;
+const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
+const PERSISTENT_BUMP_AMOUNT: u32 = 1_051_200;
+
 #[contract]
 pub struct PublisherVerificationContract;
 
@@ -81,6 +86,7 @@ pub struct PublisherVerificationContract;
 impl PublisherVerificationContract {
     /// Initialize the contract
     pub fn initialize(env: Env, admin: Address) {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
         }
@@ -93,6 +99,7 @@ impl PublisherVerificationContract {
 
     /// Register as a publisher (self-registration)
     pub fn register_publisher(env: Env, publisher: Address, domain: String) {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         publisher.require_auth();
 
         if env
@@ -125,12 +132,20 @@ impl PublisherVerificationContract {
             last_active: env.ledger().timestamp(),
         };
 
+        let _ttl_key = DataKey::Publisher(publisher.clone());
         env.storage()
             .persistent()
-            .set(&DataKey::Publisher(publisher.clone()), &pub_data);
+            .set(&_ttl_key, &pub_data);
         env.storage()
             .persistent()
-            .set(&DataKey::DomainOwner(domain), &publisher);
+            .extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        let _ttl_key = DataKey::DomainOwner(domain);
+        env.storage()
+            .persistent()
+            .set(&_ttl_key, &publisher);
+        env.storage()
+            .persistent()
+            .extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
         let count: u64 = env
             .storage()
@@ -154,6 +169,7 @@ impl PublisherVerificationContract {
         kyc_hash: String,
         kyc_provider: String,
     ) {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         publisher.require_auth();
 
         if !env
@@ -173,9 +189,13 @@ impl PublisherVerificationContract {
             verified_at: None,
         };
 
+        let _ttl_key = DataKey::KycRecord(publisher.clone());
         env.storage()
             .persistent()
-            .set(&DataKey::KycRecord(publisher.clone()), &kyc);
+            .set(&_ttl_key, &kyc);
+        env.storage()
+            .persistent()
+            .extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
         env.events().publish(
             (symbol_short!("kyc"), symbol_short!("submitted")),
@@ -190,6 +210,7 @@ impl PublisherVerificationContract {
         publisher: Address,
         initial_tier: PublisherTier,
     ) {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         admin.require_auth();
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {
@@ -207,9 +228,13 @@ impl PublisherVerificationContract {
         pub_data.verified_at = Some(env.ledger().timestamp());
         pub_data.reputation_score = 100;
 
+        let _ttl_key = DataKey::Publisher(publisher.clone());
         env.storage()
             .persistent()
-            .set(&DataKey::Publisher(publisher.clone()), &pub_data);
+            .set(&_ttl_key, &pub_data);
+        env.storage()
+            .persistent()
+            .extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
         // Mark KYC as verified
         if let Some(mut kyc) = env
@@ -219,9 +244,13 @@ impl PublisherVerificationContract {
         {
             kyc.verified = true;
             kyc.verified_at = Some(env.ledger().timestamp());
+            let _ttl_key = DataKey::KycRecord(publisher.clone());
             env.storage()
                 .persistent()
-                .set(&DataKey::KycRecord(publisher.clone()), &kyc);
+                .set(&_ttl_key, &kyc);
+            env.storage()
+                .persistent()
+                .extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
         }
 
         env.events().publish(
@@ -232,6 +261,7 @@ impl PublisherVerificationContract {
 
     /// Suspend a publisher (admin only)
     pub fn suspend_publisher(env: Env, admin: Address, publisher: Address) {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         admin.require_auth();
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {
@@ -246,13 +276,18 @@ impl PublisherVerificationContract {
 
         pub_data.status = VerificationStatus::Suspended;
 
+        let _ttl_key = DataKey::Publisher(publisher);
         env.storage()
             .persistent()
-            .set(&DataKey::Publisher(publisher), &pub_data);
+            .set(&_ttl_key, &pub_data);
+        env.storage()
+            .persistent()
+            .extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
     }
 
     /// Update publisher reputation score (admin only)
     pub fn update_reputation(env: Env, admin: Address, publisher: Address, score: u32) {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         admin.require_auth();
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {
@@ -272,13 +307,18 @@ impl PublisherVerificationContract {
         pub_data.reputation_score = score;
         pub_data.tier = Self::_score_to_tier(score);
 
+        let _ttl_key = DataKey::Publisher(publisher);
         env.storage()
             .persistent()
-            .set(&DataKey::Publisher(publisher), &pub_data);
+            .set(&_ttl_key, &pub_data);
+        env.storage()
+            .persistent()
+            .extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
     }
 
     /// Record impression (called by campaign orchestrator)
     pub fn record_impression(env: Env, caller: Address, publisher: Address, earning: i128) {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         // In production, restrict to campaign orchestrator contract only
         let mut pub_data: Publisher = env
             .storage()
@@ -295,9 +335,13 @@ impl PublisherVerificationContract {
         pub_data.total_impressions += 1;
         pub_data.last_active = env.ledger().timestamp();
 
+        let _ttl_key = DataKey::Publisher(publisher);
         env.storage()
             .persistent()
-            .set(&DataKey::Publisher(publisher), &pub_data);
+            .set(&_ttl_key, &pub_data);
+        env.storage()
+            .persistent()
+            .extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
     }
 
     // ============================================================
@@ -305,18 +349,21 @@ impl PublisherVerificationContract {
     // ============================================================
 
     pub fn get_publisher(env: Env, publisher: Address) -> Option<Publisher> {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.storage()
             .persistent()
             .get(&DataKey::Publisher(publisher))
     }
 
     pub fn get_kyc(env: Env, publisher: Address) -> Option<KycRecord> {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.storage()
             .persistent()
             .get(&DataKey::KycRecord(publisher))
     }
 
     pub fn is_verified(env: Env, publisher: Address) -> bool {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         if let Some(pub_data) = env
             .storage()
             .persistent()
@@ -329,12 +376,14 @@ impl PublisherVerificationContract {
     }
 
     pub fn get_domain_owner(env: Env, domain: String) -> Option<Address> {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.storage()
             .persistent()
             .get(&DataKey::DomainOwner(domain))
     }
 
     pub fn get_publisher_count(env: Env) -> u64 {
+        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.storage()
             .instance()
             .get(&DataKey::PublisherCount)


### PR DESCRIPTION
Every contract now calls extend_ttl after writing to persistent storage and at the top of every public function for instance storage. This prevents ledger entries from silently expiring and losing state.

TTL values by contract category:
- Campaign contracts: ~1 year (1,051,200 ledgers) persistent bump
- Auction engine: ~30 days (86,400 ledgers) persistent bump
- Governance contracts: ~90 days (259,200 ledgers) persistent bump
- All contracts: ~6 days (17,280) instance threshold, ~30 days bump

Persistent storage keys are bound to a local variable before set() and extend_ttl() to avoid use-after-move errors with non-Copy DataKey variants.

Closes #21