### PR TITLE
fix(multisig-treasury): add add_signer and remove_signer functions

### DIFF
--- a/contracts/multisig-treasury/src/lib.rs
+++ b/contracts/multisig-treasury/src/lib.rs
@@ -3,8 +3,7 @@
 
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short,
-    token, Address, Env, String, Vec,
+    contract, contractimpl, contracttype, symbol_short, token, Address, Env, String, Vec,
 };
 
 #[contracttype]
@@ -56,7 +55,9 @@ pub struct MultisigTreasuryContract;
 #[contractimpl]
 impl MultisigTreasuryContract {
     pub fn initialize(env: Env, admin: Address, initial_signers: Vec<Address>, required: u32) {
-        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
         }
@@ -67,8 +68,12 @@ impl MultisigTreasuryContract {
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::Signers, &initial_signers);
-        env.storage().instance().set(&DataKey::RequiredSigners, &required);
+        env.storage()
+            .instance()
+            .set(&DataKey::Signers, &initial_signers);
+        env.storage()
+            .instance()
+            .set(&DataKey::RequiredSigners, &required);
         env.storage().instance().set(&DataKey::TxCounter, &0u64);
     }
 
@@ -81,7 +86,9 @@ impl MultisigTreasuryContract {
         description: String,
         expires_in: u64,
     ) -> u64 {
-        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         proposer.require_auth();
 
         let signers: Vec<Address> = env.storage().instance().get(&DataKey::Signers).unwrap();
@@ -95,9 +102,17 @@ impl MultisigTreasuryContract {
             panic!("invalid amount");
         }
 
-        let counter: u64 = env.storage().instance().get(&DataKey::TxCounter).unwrap_or(0);
+        let counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TxCounter)
+            .unwrap_or(0);
         let tx_id = counter + 1;
-        let required: u32 = env.storage().instance().get(&DataKey::RequiredSigners).unwrap();
+        let required: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RequiredSigners)
+            .unwrap();
 
         let tx = TreasuryTx {
             tx_id,
@@ -117,7 +132,11 @@ impl MultisigTreasuryContract {
 
         let _ttl_key = DataKey::Tx(tx_id);
         env.storage().persistent().set(&_ttl_key, &tx);
-        env.storage().persistent().extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
         env.storage().instance().set(&DataKey::TxCounter, &tx_id);
 
         env.events().publish(
@@ -129,7 +148,9 @@ impl MultisigTreasuryContract {
     }
 
     pub fn approve_transaction(env: Env, signer: Address, tx_id: u64) {
-        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         signer.require_auth();
 
         let signers: Vec<Address> = env.storage().instance().get(&DataKey::Signers).unwrap();
@@ -137,7 +158,11 @@ impl MultisigTreasuryContract {
             panic!("not a signer");
         }
 
-        if env.storage().persistent().has(&DataKey::TxApproval(tx_id, signer.clone())) {
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::TxApproval(tx_id, signer.clone()))
+        {
             panic!("already voted");
         }
 
@@ -155,14 +180,22 @@ impl MultisigTreasuryContract {
             tx.status = TxStatus::Expired;
             let _ttl_key = DataKey::Tx(tx_id);
             env.storage().persistent().set(&_ttl_key, &tx);
-            env.storage().persistent().extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+            env.storage().persistent().extend_ttl(
+                &_ttl_key,
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
             panic!("tx expired");
         }
 
         tx.approvals += 1;
         let _ttl_key = DataKey::TxApproval(tx_id, signer);
         env.storage().persistent().set(&_ttl_key, &true);
-        env.storage().persistent().extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
 
         if tx.approvals >= tx.required_approvals {
             tx.status = TxStatus::Approved;
@@ -170,11 +203,17 @@ impl MultisigTreasuryContract {
 
         let _ttl_key = DataKey::Tx(tx_id);
         env.storage().persistent().set(&_ttl_key, &tx);
-        env.storage().persistent().extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
     }
 
     pub fn execute_transaction(env: Env, caller: Address, tx_id: u64) {
-        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         caller.require_auth();
 
         let signers: Vec<Address> = env.storage().instance().get(&DataKey::Signers).unwrap();
@@ -193,17 +232,17 @@ impl MultisigTreasuryContract {
         }
 
         let token_client = token::Client::new(&env, &tx.token);
-        token_client.transfer(
-            &env.current_contract_address(),
-            &tx.recipient,
-            &tx.amount,
-        );
+        token_client.transfer(&env.current_contract_address(), &tx.recipient, &tx.amount);
 
         tx.status = TxStatus::Executed;
         tx.executed_at = Some(env.ledger().timestamp());
         let _ttl_key = DataKey::Tx(tx_id);
         env.storage().persistent().set(&_ttl_key, &tx);
-        env.storage().persistent().extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
 
         env.events().publish(
             (symbol_short!("treasury"), symbol_short!("executed")),
@@ -212,7 +251,9 @@ impl MultisigTreasuryContract {
     }
 
     pub fn reject_transaction(env: Env, signer: Address, tx_id: u64) {
-        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         signer.require_auth();
 
         let signers: Vec<Address> = env.storage().instance().get(&DataKey::Signers).unwrap();
@@ -233,7 +274,11 @@ impl MultisigTreasuryContract {
         tx.rejections += 1;
 
         let total_signers = signers.len() as u32;
-        let required: u32 = env.storage().instance().get(&DataKey::RequiredSigners).unwrap();
+        let required: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RequiredSigners)
+            .unwrap();
         let max_possible_approvals = total_signers - tx.rejections;
 
         if max_possible_approvals < required {
@@ -242,17 +287,103 @@ impl MultisigTreasuryContract {
 
         let _ttl_key = DataKey::Tx(tx_id);
         env.storage().persistent().set(&_ttl_key, &tx);
-        env.storage().persistent().extend_ttl(&_ttl_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
     }
 
     pub fn get_transaction(env: Env, tx_id: u64) -> Option<TreasuryTx> {
-        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.storage().persistent().get(&DataKey::Tx(tx_id))
     }
 
     pub fn get_signers(env: Env) -> Vec<Address> {
-        env.storage().instance().extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.storage().instance().get(&DataKey::Signers).unwrap()
+    }
+
+    pub fn add_signer(env: Env, admin: Address, new_signer: Address) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+
+        let mut signers: Vec<Address> = env.storage().instance().get(&DataKey::Signers).unwrap();
+        if signers.contains(&new_signer) {
+            panic!("already a signer");
+        }
+
+        signers.push_back(new_signer.clone());
+        env.storage().instance().set(&DataKey::Signers, &signers);
+
+        env.events().publish(
+            (symbol_short!("treasury"), symbol_short!("sgn_add")),
+            new_signer,
+        );
+    }
+
+    pub fn remove_signer(env: Env, admin: Address, signer: Address) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+
+        let mut signers: Vec<Address> = env.storage().instance().get(&DataKey::Signers).unwrap();
+        let required: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RequiredSigners)
+            .unwrap();
+
+        if !signers.contains(&signer) {
+            panic!("not a signer");
+        }
+
+        // Removing must not drop total signers below required threshold
+        if signers.len() as u32 - 1 < required {
+            panic!("cannot remove: would breach required signers threshold");
+        }
+
+        // Rebuild vec without the removed signer
+        let mut new_signers: Vec<Address> = Vec::new(&env);
+        for s in signers.iter() {
+            if s != signer {
+                new_signers.push_back(s);
+            }
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Signers, &new_signers);
+
+        env.events().publish(
+            (symbol_short!("treasury"), symbol_short!("sgn_rem")),
+            signer,
+        );
     }
 }
 

--- a/contracts/multisig-treasury/src/test.rs
+++ b/contracts/multisig-treasury/src/test.rs
@@ -3,13 +3,14 @@ use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token::{Client as TokenClient, StellarAssetClient},
-    Address, Env, String, vec,
+    vec, Address, Env, String,
 };
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 fn deploy_token(env: &Env, admin: &Address) -> Address {
-    env.register_stellar_asset_contract_v2(admin.clone()).address()
+    env.register_stellar_asset_contract_v2(admin.clone())
+        .address()
 }
 
 fn mint(env: &Env, token_addr: &Address, to: &Address, amount: i128) {
@@ -17,7 +18,15 @@ fn mint(env: &Env, token_addr: &Address, to: &Address, amount: i128) {
     sac.mint(to, &amount);
 }
 
-fn setup(env: &Env) -> (MultisigTreasuryContractClient, Address, Vec<Address>, Address, Address) {
+fn setup(
+    env: &Env,
+) -> (
+    MultisigTreasuryContractClient,
+    Address,
+    Vec<Address>,
+    Address,
+    Address,
+) {
     let admin = Address::generate(env);
     let signer1 = Address::generate(env);
     let signer2 = Address::generate(env);
@@ -124,7 +133,12 @@ fn test_propose_transaction() {
     let proposer = signers.get(0).unwrap();
 
     let tx_id = client.propose_transaction(
-        &proposer, &recipient, &token_addr, &10_000i128, &make_desc(&env), &86_400u64,
+        &proposer,
+        &recipient,
+        &token_addr,
+        &10_000i128,
+        &make_desc(&env),
+        &86_400u64,
     );
 
     assert_eq!(tx_id, 1);
@@ -146,7 +160,14 @@ fn test_propose_by_non_signer() {
     let stranger = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    client.propose_transaction(&stranger, &recipient, &token_addr, &10_000i128, &make_desc(&env), &86_400u64);
+    client.propose_transaction(
+        &stranger,
+        &recipient,
+        &token_addr,
+        &10_000i128,
+        &make_desc(&env),
+        &86_400u64,
+    );
 }
 
 #[test]
@@ -159,7 +180,14 @@ fn test_propose_zero_amount() {
     let proposer = signers.get(0).unwrap();
     let recipient = Address::generate(&env);
 
-    client.propose_transaction(&proposer, &recipient, &token_addr, &0i128, &make_desc(&env), &86_400u64);
+    client.propose_transaction(
+        &proposer,
+        &recipient,
+        &token_addr,
+        &0i128,
+        &make_desc(&env),
+        &86_400u64,
+    );
 }
 
 // ─── approve_transaction ─────────────────────────────────────────────────────
@@ -174,7 +202,14 @@ fn test_approve_transaction() {
     let signer2 = signers.get(1).unwrap();
     let recipient = Address::generate(&env);
 
-    let tx_id = client.propose_transaction(&proposer, &recipient, &token_addr, &10_000i128, &make_desc(&env), &86_400u64);
+    let tx_id = client.propose_transaction(
+        &proposer,
+        &recipient,
+        &token_addr,
+        &10_000i128,
+        &make_desc(&env),
+        &86_400u64,
+    );
 
     client.approve_transaction(&proposer, &tx_id);
     let tx = client.get_transaction(&tx_id).unwrap();
@@ -197,7 +232,14 @@ fn test_approve_twice() {
     let proposer = signers.get(0).unwrap();
     let recipient = Address::generate(&env);
 
-    let tx_id = client.propose_transaction(&proposer, &recipient, &token_addr, &10_000i128, &make_desc(&env), &86_400u64);
+    let tx_id = client.propose_transaction(
+        &proposer,
+        &recipient,
+        &token_addr,
+        &10_000i128,
+        &make_desc(&env),
+        &86_400u64,
+    );
 
     client.approve_transaction(&proposer, &tx_id);
     client.approve_transaction(&proposer, &tx_id);
@@ -214,7 +256,14 @@ fn test_approve_by_non_signer() {
     let stranger = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    let tx_id = client.propose_transaction(&proposer, &recipient, &token_addr, &10_000i128, &make_desc(&env), &86_400u64);
+    let tx_id = client.propose_transaction(
+        &proposer,
+        &recipient,
+        &token_addr,
+        &10_000i128,
+        &make_desc(&env),
+        &86_400u64,
+    );
 
     client.approve_transaction(&stranger, &tx_id);
 }
@@ -229,9 +278,18 @@ fn test_approve_expired_transaction() {
     let proposer = signers.get(0).unwrap();
     let recipient = Address::generate(&env);
 
-    let tx_id = client.propose_transaction(&proposer, &recipient, &token_addr, &10_000i128, &make_desc(&env), &100u64);
+    let tx_id = client.propose_transaction(
+        &proposer,
+        &recipient,
+        &token_addr,
+        &10_000i128,
+        &make_desc(&env),
+        &100u64,
+    );
 
-    env.ledger().with_mut(|li| { li.timestamp = 200; });
+    env.ledger().with_mut(|li| {
+        li.timestamp = 200;
+    });
 
     client.approve_transaction(&proposer, &tx_id);
 }
@@ -258,7 +316,14 @@ fn test_execute_transaction() {
     mint(&env, &token_addr, &contract_id, 1_000_000);
 
     let recipient = Address::generate(&env);
-    let tx_id = client.propose_transaction(&signer1, &recipient, &token_addr, &50_000i128, &make_desc(&env), &86_400u64);
+    let tx_id = client.propose_transaction(
+        &signer1,
+        &recipient,
+        &token_addr,
+        &50_000i128,
+        &make_desc(&env),
+        &86_400u64,
+    );
 
     client.approve_transaction(&signer1, &tx_id);
     client.approve_transaction(&signer2, &tx_id);
@@ -283,7 +348,14 @@ fn test_execute_pending_transaction() {
     let proposer = signers.get(0).unwrap();
     let recipient = Address::generate(&env);
 
-    let tx_id = client.propose_transaction(&proposer, &recipient, &token_addr, &10_000i128, &make_desc(&env), &86_400u64);
+    let tx_id = client.propose_transaction(
+        &proposer,
+        &recipient,
+        &token_addr,
+        &10_000i128,
+        &make_desc(&env),
+        &86_400u64,
+    );
 
     // Not yet approved → should panic
     client.execute_transaction(&proposer, &tx_id);
@@ -301,7 +373,14 @@ fn test_reject_transaction() {
     let signer2 = signers.get(1).unwrap();
     let recipient = Address::generate(&env);
 
-    let tx_id = client.propose_transaction(&proposer, &recipient, &token_addr, &10_000i128, &make_desc(&env), &86_400u64);
+    let tx_id = client.propose_transaction(
+        &proposer,
+        &recipient,
+        &token_addr,
+        &10_000i128,
+        &make_desc(&env),
+        &86_400u64,
+    );
 
     // 3 signers, required=2 → need 2+ rejections to get Rejected status
     client.reject_transaction(&proposer, &tx_id);
@@ -326,7 +405,14 @@ fn test_reject_by_non_signer() {
     let stranger = Address::generate(&env);
     let recipient = Address::generate(&env);
 
-    let tx_id = client.propose_transaction(&proposer, &recipient, &token_addr, &10_000i128, &make_desc(&env), &86_400u64);
+    let tx_id = client.propose_transaction(
+        &proposer,
+        &recipient,
+        &token_addr,
+        &10_000i128,
+        &make_desc(&env),
+        &86_400u64,
+    );
 
     client.reject_transaction(&stranger, &tx_id);
 }
@@ -350,4 +436,94 @@ fn test_get_signers() {
 
     let stored = client.get_signers();
     assert_eq!(stored.len(), signers.len());
+}
+
+// signer management
+
+#[test]
+fn test_add_signer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _, _) = setup(&env);
+
+    let new_signer = Address::generate(&env);
+    client.add_signer(&admin, &new_signer);
+
+    let signers = client.get_signers();
+    assert_eq!(signers.len(), 4); // was 3, now 4
+    assert!(signers.contains(&new_signer));
+}
+
+#[test]
+#[should_panic(expected = "already a signer")]
+fn test_add_signer_duplicate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signers, _, _) = setup(&env);
+
+    let existing = signers.get(0).unwrap();
+    client.add_signer(&admin, &existing);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_add_signer_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _, _) = setup(&env);
+
+    let stranger = Address::generate(&env);
+    let new_signer = Address::generate(&env);
+    client.add_signer(&stranger, &new_signer);
+}
+
+#[test]
+fn test_remove_signer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signers, _, _) = setup(&env);
+
+    let to_remove = signers.get(2).unwrap(); // remove 3rd; 2 remain >= required(2)
+    client.remove_signer(&admin, &to_remove);
+
+    let updated = client.get_signers();
+    assert_eq!(updated.len(), 2);
+    assert!(!updated.contains(&to_remove));
+}
+
+#[test]
+#[should_panic(expected = "cannot remove: would breach required signers threshold")]
+fn test_remove_signer_below_required() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, signers, _, _) = setup(&env);
+
+    // required=2, removing 2 signers would leave 1 < 2
+    let s1 = signers.get(0).unwrap();
+    let s2 = signers.get(1).unwrap();
+    client.remove_signer(&admin, &s1);
+    client.remove_signer(&admin, &s2); // this should panic
+}
+
+#[test]
+#[should_panic(expected = "not a signer")]
+fn test_remove_signer_nonexistent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _, _) = setup(&env);
+
+    let ghost = Address::generate(&env);
+    client.remove_signer(&admin, &ghost);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_remove_signer_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, signers, _, _) = setup(&env);
+
+    let stranger = Address::generate(&env);
+    let target = signers.get(0).unwrap();
+    client.remove_signer(&stranger, &target);
 }


### PR DESCRIPTION
**Title:**

fix(multisig-treasury): add signer management (add_signer / remove_signer) [#66]


**Description:**

## Problem
The multisig-treasury contract had no way to modify the signers list after
initialization. A compromised or departed signer's key could never be revoked,
and losing enough keys could permanently lock treasury funds.

Fixes #66

## Changes
**`contracts/multisig-treasury/src/lib.rs`**
- `add_signer(admin, new_signer)` — admin-only; appends a signer; panics if duplicate
- `remove_signer(admin, signer)` — admin-only; removes a signer; panics if removal
  would leave fewer signers than the required threshold

**`contracts/multisig-treasury/src/test.rs`**
- 7 new tests covering both happy paths and all failure cases

## Safety Invariant
`remove_signer` enforces `remaining_signers >= required_signers` at all times,
so the treasury can never reach a state where the approval threshold is
unreachable.

## Testing
cargo test -- all passing

## Proof
<img width="1136" height="880" alt="Screenshot 2026-02-23 at 18 45 34" src="https://github.com/user-attachments/assets/d6dc9373-e762-4246-b1dc-eda07135d6be" />

