### PR TITLE
Frontend and backend package.json missing test scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,9 +7,11 @@
     "dev": "nodemon --exec ts-node src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "vitest run",
+    "test": "vitest",
+    "test:coverage": "vitest --coverage",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "typecheck": "tsc --noEmit",
+    "audit": "npm audit --audit-level=high"
   },
   "keywords": [],
   "author": "",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest --coverage",
+    "test:watch": "vitest --watch",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
I have updated the scripts section in both the frontend and backend 
package.json
 files to include standardized testing, type checking, and security auditing commands.

Changes Made
Frontend
Added and updated the following scripts in 
frontend/package.json
:

test: Standardized to vitest
test:coverage: Updated to vitest --coverage
test:watch: Added vitest --watch
typecheck: Added tsc --noEmit
Backend
Added and updated the following scripts in 
backend/package.json
:

test: Normalized to vitest
test:coverage: Updated to vitest --coverage
typecheck: Added tsc --noEmit
audit: Added npm audit --audit-level=high
Verification Results
Frontend TypeCheck
Running npm run typecheck in the frontend directory successfully invoked the TypeScript compiler.

bash
> frontend@0.1.0 typecheck
> tsc --noEmit
(Note: This revealed some pre-existing type errors in src/hooks/useContract.test.ts which were not part of this task to fix, but confirm the script is working.)

Backend Audit
Running npm run audit in the backend directory successfully performed a security scan.

bash
> pulsartrack-backend@1.0.0 audit
> npm audit --audit-level=high
found 0 vulnerabilities
Script Inventory
I verified that all requested scripts are present in the respective files.

Frontend Scripts
json
"scripts": {
    "dev": "next dev",
    "build": "next build",
    "start": "next start",
    "lint": "eslint",
    "test": "vitest",
    "test:coverage": "vitest --coverage",
    "test:watch": "vitest --watch",
    "typecheck": "tsc --noEmit"
  },
Backend Scripts
json
"scripts": {
    "dev": "nodemon --exec ts-node src/index.ts",
    "build": "tsc",
    "start": "node dist/index.js",
    "test": "vitest",
    "test:coverage": "vitest --coverage",
    "test:watch": "vitest",
    "typecheck": "tsc --noEmit",
    "audit": "npm audit --audit-level=high"
  },


Close #132 