### PR TITLE
fix(contract): align publisher tier thresholds with frontend standard

### DIFF
--- a/contracts/publisher-verification/src/lib.rs
+++ b/contracts/publisher-verification/src/lib.rs
@@ -413,9 +413,9 @@ impl PublisherVerificationContract {
     fn _score_to_tier(score: u32) -> PublisherTier {
         if score >= 800 {
             PublisherTier::Platinum
-        } else if score >= 500 {
+        } else if score >= 600 {
             PublisherTier::Gold
-        } else if score >= 200 {
+        } else if score >= 400 {
             PublisherTier::Silver
         } else {
             PublisherTier::Bronze


### PR DESCRIPTION
## 🏆 Publisher Tier Thresholds Alignment

Aligns the `publisher-verification` contract tier thresholds with the frontend and overall system standards.

### Changes
- Updated `_score_to_tier` in `contracts/publisher-verification/src/lib.rs`.
- Standardized thresholds:
  - **Platinum**: 800 - 1000
  - **Gold**: 600 - 799
  - **Silver**: 400 - 599
  - **Bronze**: 0 - 399

Closes #126
