### PR TITLE
fix: add Open Graph, Twitter meta tags, and page-specific metadata

### DIFF
--- a/frontend/src/app/advertiser/layout.tsx
+++ b/frontend/src/app/advertiser/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+    title: "Advertiser Dashboard",
+    description: "Create and manage ad campaigns on PulsarTrack. Real-time bidding, budget controls, and on-chain analytics powered by Stellar and Soroban smart contracts.",
+    openGraph: {
+        title: "Advertiser Dashboard | PulsarTrack",
+        description: "Create and manage ad campaigns on PulsarTrack. Real-time bidding, budget controls, and on-chain analytics powered by Stellar and Soroban smart contracts.",
+    },
+    twitter: {
+        title: "Advertiser Dashboard | PulsarTrack",
+        description: "Create and manage ad campaigns on PulsarTrack. Real-time bidding, budget controls, and on-chain analytics powered by Stellar and Soroban smart contracts.",
+    },
+};
+
+export default function AdvertiserLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return children;
+}

--- a/frontend/src/app/governance/layout.tsx
+++ b/frontend/src/app/governance/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+    title: "Governance",
+    description: "Participate in PulsarTrack DAO governance. Vote on proposals with PULSAR tokens and shape the future of decentralized ad tracking on Stellar.",
+    openGraph: {
+        title: "Governance | PulsarTrack",
+        description: "Participate in PulsarTrack DAO governance. Vote on proposals with PULSAR tokens and shape the future of decentralized ad tracking on Stellar.",
+    },
+    twitter: {
+        title: "Governance | PulsarTrack",
+        description: "Participate in PulsarTrack DAO governance. Vote on proposals with PULSAR tokens and shape the future of decentralized ad tracking on Stellar.",
+    },
+};
+
+export default function GovernanceLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return children;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://pulsartrack.io'), // Placeholder URL, update as needed
+  metadataBase: new URL('https://pulsartrack.io'),
   title: {
     default: "PulsarTrack - Decentralized Ad Tracking on Stellar",
     template: "%s | PulsarTrack"
@@ -23,6 +23,10 @@ export const metadata: Metadata = {
   description: "Privacy-preserving, blockchain-powered advertising platform on the Stellar network. Real-time bidding, on-chain reputation, and instant XLM settlements.",
   keywords: ["Stellar", "Blockchain", "Ad Tracking", "RTB", "DeFi", "Privacy-preserving", "Soroban"],
   authors: [{ name: "PulsarTrack Team" }],
+  icons: {
+    icon: "/favicon.ico",
+    apple: "/og-image.png",
+  },
   openGraph: {
     type: "website",
     locale: "en_US",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,19 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import { TrendingUp, Users, Shield, Zap, Radio, Lock, BarChart3, Globe } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "PulsarTrack - Decentralized Ad Tracking on Stellar",
+  description: "Privacy-preserving, blockchain-powered advertising platform on the Stellar network. Real-time bidding, on-chain reputation, and instant XLM settlements.",
+  openGraph: {
+    title: "PulsarTrack - Decentralized Ad Tracking on Stellar",
+    description: "Privacy-preserving, blockchain-powered advertising platform on the Stellar network. Real-time bidding, on-chain reputation, and instant XLM settlements.",
+  },
+  twitter: {
+    title: "PulsarTrack - Decentralized Ad Tracking on Stellar",
+    description: "Privacy-preserving, blockchain-powered advertising platform on the Stellar network. Real-time bidding, on-chain reputation, and instant XLM settlements.",
+  },
+};
 
 export default function Home() {
   return (

--- a/frontend/src/app/publisher/layout.tsx
+++ b/frontend/src/app/publisher/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+    title: "Publisher Dashboard",
+    description: "Monetize your ad inventory on PulsarTrack. Earn XLM through real-time bidding auctions, track your reputation score, and manage subscriptions on Stellar.",
+    openGraph: {
+        title: "Publisher Dashboard | PulsarTrack",
+        description: "Monetize your ad inventory on PulsarTrack. Earn XLM through real-time bidding auctions, track your reputation score, and manage subscriptions on Stellar.",
+    },
+    twitter: {
+        title: "Publisher Dashboard | PulsarTrack",
+        description: "Monetize your ad inventory on PulsarTrack. Earn XLM through real-time bidding auctions, track your reputation score, and manage subscriptions on Stellar.",
+    },
+};
+
+export default function PublisherLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return children;
+}


### PR DESCRIPTION
Add icons configuration (favicon and apple-touch-icon) to the root layout metadata. Add page-specific metadata exports for all route pages so each page renders its own title and description in social sharing previews.

Since the advertiser, publisher, and governance pages are client components, their metadata is exported from per-route layout files instead.

Closes #164