### PR TITLE
fix(campaign-orchestrator): use persistent storage for daily view cou…

### DIFF
--- a/contracts/campaign-orchestrator/src/lib.rs
+++ b/contracts/campaign-orchestrator/src/lib.rs
@@ -118,6 +118,8 @@ const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
 const INSTANCE_BUMP_AMOUNT: u32 = 86_400;
 const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
 const PERSISTENT_BUMP_AMOUNT: u32 = 1_051_200;
+const DAILY_VIEWS_LIFETIME_THRESHOLD: u32 = 17_280;
+const DAILY_VIEWS_BUMP_AMOUNT: u32 = 34_560;
 
 #[contract]
 pub struct CampaignOrchestratorContract;
@@ -361,7 +363,7 @@ impl CampaignOrchestratorContract {
         // Check daily view limit
         let current_day = env.ledger().timestamp() / 86_400;
         let daily_key = DataKey::DailyViews(campaign_id, current_day);
-        let daily_views: u64 = env.storage().temporary().get(&daily_key).unwrap_or(0);
+        let daily_views: u64 = env.storage().persistent().get(&daily_key).unwrap_or(0);
 
         if daily_views >= campaign.daily_view_limit {
             panic!("daily view limit reached");
@@ -397,8 +399,13 @@ impl CampaignOrchestratorContract {
             PERSISTENT_BUMP_AMOUNT,
         );
         env.storage()
-            .temporary()
+            .persistent()
             .set(&daily_key, &(daily_views + 1));
+        env.storage().persistent().extend_ttl(
+            &daily_key,
+            DAILY_VIEWS_LIFETIME_THRESHOLD,
+            DAILY_VIEWS_BUMP_AMOUNT,
+        );
 
         // Update publisher earnings
         Self::_update_publisher_earnings(&env, &publisher, campaign.cost_per_view);


### PR DESCRIPTION
Changes made:

Added DAILY_VIEWS_LIFETIME_THRESHOLD (17,280 ledgers = ~1 day) and DAILY_VIEWS_BUMP_AMOUNT (34,560 ledgers = ~2 days) constants
Changed env.storage().temporary() to env.storage().persistent() for both reading and writing daily view counts
Added TTL extension after updating the daily view counter to ensure it persists for at least 24 hours

Closes #193 