### PR TITLE
fix: validate contract IDs on startup to prevent silent failures

### DIFF
--- a/backend/src/config/stellar.ts
+++ b/backend/src/config/stellar.ts
@@ -1,4 +1,5 @@
 import { Horizon, Networks } from '@stellar/stellar-sdk';
+import { logger } from '../lib/logger';
 
 const NETWORK = process.env.STELLAR_NETWORK || 'testnet';
 const HORIZON_URL =
@@ -70,3 +71,48 @@ export const CONTRACT_IDS = {
   AD_VERIFICATION: process.env.CONTRACT_AD_VERIFICATION || '',
   PUBLISHER_NETWORK: process.env.CONTRACT_PUBLISHER_NETWORK || '',
 };
+
+/**
+ * Core contracts required for the platform to function.
+ * All others are optional/feature-flagged.
+ */
+const REQUIRED_CONTRACT_ENV_VARS = [
+  'CONTRACT_AD_REGISTRY',
+  'CONTRACT_CAMPAIGN_ORCHESTRATOR',
+  'CONTRACT_ESCROW_VAULT',
+  'CONTRACT_FRAUD_PREVENTION',
+  'CONTRACT_PAYMENT_PROCESSOR',
+  'CONTRACT_AUCTION_ENGINE',
+  'CONTRACT_REVENUE_SETTLEMENT',
+  'CONTRACT_PUBLISHER_VERIFICATION',
+  'CONTRACT_ANALYTICS_AGGREGATOR',
+];
+
+/**
+ * Validates that all required contract IDs are present.
+ * - In production: throws on any missing value, preventing startup.
+ * - In development: logs a warning for each missing value so the server
+ *   still starts (useful when only testing non-contract routes).
+ * Pass SKIP_CONTRACT_VALIDATION=true to suppress even the warnings.
+ */
+export function validateContractIds(): void {
+  if (process.env.SKIP_CONTRACT_VALIDATION === 'true') {
+    logger.warn('[Config] Contract ID validation skipped (SKIP_CONTRACT_VALIDATION=true)');
+    return;
+  }
+
+  const missing = REQUIRED_CONTRACT_ENV_VARS.filter(
+    (key) => !process.env[key] || process.env[key] === 'PLACEHOLDER',
+  );
+
+  if (missing.length === 0) return;
+
+  const message = `Missing or placeholder contract IDs:\n  ${missing.join('\n  ')}`;
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(`[Config] ${message}\nSet these environment variables before starting the server.`);
+  }
+
+  logger.warn(`[Config] ${message}`);
+  logger.warn('[Config] Contract calls will fail for the above contracts. Set SKIP_CONTRACT_VALIDATION=true to suppress this warning.');
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from "./middleware/auth";
 import { setupWebSocketServer } from "./services/websocket-server";
 import { checkDbConnection } from "./config/database";
+import { validateContractIds } from "./config/stellar";
 import prisma from "./db/prisma";
 import redisClient from "./config/redis";
 
@@ -63,6 +64,9 @@ setupWebSocketServer(server);
 
 // Start server
 async function start() {
+  // Validate contract IDs — throws in production, warns in development
+  validateContractIds();
+
   // Verify database connection — fail hard in production
   const dbOk = await checkDbConnection();
   if (!dbOk) {

--- a/backend/src/services/soroban-client.ts
+++ b/backend/src/services/soroban-client.ts
@@ -25,6 +25,13 @@ export async function callReadOnly(
   method: string,
   args: xdr.ScVal[] = [],
 ): Promise<any> {
+  if (!contractId || contractId === 'PLACEHOLDER') {
+    throw new Error(
+      `callReadOnly("${method}"): contract ID is missing or a placeholder. ` +
+      `Set the corresponding CONTRACT_* environment variable.`,
+    );
+  }
+
   const server = getServer();
   const contract = new Contract(contractId);
   const account = await server.getAccount(SIMULATION_ACCOUNT);


### PR DESCRIPTION
Closes #228 

## Problem

`backend/src/config/stellar.ts` defaulted all 44 contract IDs to empty strings when environment variables were missing or set to `PLACEHOLDER`. The server started without complaint and only failed when an API route attempted a Soroban contract call, producing cryptic RPC errors that were difficult to trace back to a missing env var.

This affected new contributors, CI environments, and docker-compose setups where `PLACEHOLDER` values ship by default.

## Changes

**`backend/src/config/stellar.ts`**
- Added `validateContractIds()` which checks the 9 core contracts against empty strings and `PLACEHOLDER` values
- In `production`: throws an error listing all missing variables, preventing the server from starting
- In `development`: logs a warning per missing variable, server still starts for non-contract route testing
- Set `SKIP_CONTRACT_VALIDATION=true` to suppress validation entirely

**`backend/src/index.ts`**
- Calls `validateContractIds()` at the top of `start()`, before the DB check and before the server binds to a port

**`backend/src/services/soroban-client.ts`**
- Added an early guard in `callReadOnly()` that throws a clear, actionable error if a contract ID is empty or `PLACEHOLDER`, catching any cases where validation was skipped

## Behaviour After Fix

| Environment | Missing contract ID | Result |
|---|---|---|
| `production` | any required contract | server refuses to start, lists missing vars |
| `development` | any required contract | warning logged, server starts |
| any | `SKIP_CONTRACT_VALIDATION=true` | validation skipped, warning logged |
| any | empty/placeholder passed to `callReadOnly` | immediate error naming the method and missing var |

## Testing

Start the backend without setting any `CONTRACT_*` env vars and confirm:
- In `NODE_ENV=production`: process exits with a clear error listing missing variables
- In `NODE_ENV=development`: server starts with warnings in the log
- With `SKIP_CONTRACT_VALIDATION=true`: no warnings, server starts normally
