### PR TITLE
fix: add missing return statement in rateLimitWrite middleware

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -197,6 +197,7 @@ export function rateLimitWrite() {
       res
         .status(429)
         .json({ error: "Write rate limit exceeded (10 per hour)" });
+      return;
     }
   };
 }


### PR DESCRIPTION
close #247 
- Add return statement after sending 429 response in catch block
- Prevents execution from continuing to route handler when rate limited
- Fixes potential 'headers already sent' errors
- Ensures write operations are properly blocked when rate limit exceeded
- Protects campaign creation, bid placement, and publisher registration endpoints