### PR TITLE
Fix/trust proxy configuration

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,12 @@ import redisClient from "./config/redis";
 const app = express();
 const PORT = parseInt(process.env.PORT || "4000", 10);
 
+// Trust proxy when behind reverse proxy/load balancer (nginx, Cloudflare, AWS ALB)
+// This ensures req.ip returns the real client IP from X-Forwarded-For header
+if (process.env.NODE_ENV === "production") {
+  app.set("trust proxy", 1); // Trust first proxy
+}
+
 // Initialize Redis-backed rate limiters
 configureRateLimiters(redisClient);
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -155,7 +155,7 @@ export function rateLimit() {
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const ip = req.ip || req.connection.remoteAddress || "unknown";
+    const ip = req.ip || "unknown";
 
     try {
       await ipLimiter.consume(ip);


### PR DESCRIPTION
Close #248 
Backend didn't trust reverse proxies, causing req.ip to return the proxy's IP instead of real client IPs. This made IP-based rate limiting ineffective - all users appeared as the same IP and shared one rate limit pool.

Solution
Added app.set("trust proxy", 1) in production mode
Removed deprecated req.connection.remoteAddress
Now correctly extracts real client IPs from X-Forwarded-For headers
Impact
Fixes IP-based rate limiting behind nginx, Cloudflare, AWS ALB, and other reverse proxies