### PR TITLE
fix: enforce expiry check in multisig-treasury execute_transaction

### DIFF
--- a/contracts/multisig-treasury/src/lib.rs
+++ b/contracts/multisig-treasury/src/lib.rs
@@ -233,6 +233,12 @@ impl MultisigTreasuryContract {
             panic!("tx not approved");
         }
 
+        if env.ledger().timestamp() > tx.expires_at {
+            tx.status = TxStatus::Expired;
+            env.storage().persistent().set(&DataKey::Tx(tx_id), &tx);
+            panic!("transaction expired");
+        }
+
         let token_client = token::Client::new(&env, &tx.token);
         token_client.transfer(&env.current_contract_address(), &tx.recipient, &tx.amount);
 


### PR DESCRIPTION
CLoses #237 

## Problem

`contracts/multisig-treasury/src/lib.rs` — `execute_transaction` checked that a transaction's status was `Approved` but never verified whether it had passed its `expires_at` timestamp. Any approved transaction could be executed indefinitely, regardless of when it was originally approved.

This is a high-severity issue for a treasury contract. Examples of real impact:

- A disbursement approved at a low token price could be executed much later when the token is worth significantly more, draining far more value than intended
- A transaction approved before a security incident could be replayed after the incident to exfiltrate funds
- Governance conditions, signers, or risk context may have changed entirely since the original approval

## Changes

**`contracts/multisig-treasury/src/lib.rs`**

Added an expiry check in `execute_transaction` immediately after the `Approved` status check:

```rust
if env.ledger().timestamp() > tx.expires_at {
    tx.status = TxStatus::Expired;
    env.storage().persistent().set(&DataKey::Tx(tx_id), &tx);
    panic!("transaction expired");
}
```