### PR TITLE
fix: add caller.require_auth() to settle_auction in auction-engine

### DIFF
--- a/contracts/auction-engine/src/lib.rs
+++ b/contracts/auction-engine/src/lib.rs
@@ -254,6 +254,7 @@ impl AuctionEngineContract {
     }
 
     pub fn settle_auction(env: Env, caller: Address, auction_id: u64) {
+        caller.require_auth();
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);


### PR DESCRIPTION
Closes #236 

## Problem

`contracts/auction-engine/src/lib.rs` — `settle_auction` was missing `caller.require_auth()`, meaning the `caller` parameter was never cryptographically verified by the Soroban runtime.

In Soroban, passing an `Address` as a function argument does not prove the transaction signer controls that address. Only `require_auth()` does. Without it, an attacker could pass the publisher's or admin's address as `caller` and bypass the identity check entirely:

```rust
if caller != auction.publisher && caller != admin {
    panic!("unauthorized");
}
```