### PR TITLE
Add timeouts for Stellar HTTP calls

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,10 @@ import apiRoutes from './api/routes';
 import { errorHandler, rateLimit, configureRateLimiters } from './middleware/auth';
 
 const app = express();
+const RESPONSE_TIMEOUT_MS = Number.parseInt(
+    process.env.EXPRESS_RESPONSE_TIMEOUT_MS || '30000',
+    10,
+);
 
 // Redis connection for rate limiting
 const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
@@ -36,6 +40,15 @@ if (process.env.NODE_ENV !== 'test') {
 }
 
 app.use(express.json({ limit: '10mb' }));
+app.use((req, res, next) => {
+    req.setTimeout(RESPONSE_TIMEOUT_MS);
+    res.setTimeout(RESPONSE_TIMEOUT_MS, () => {
+        if (!res.headersSent) {
+            res.status(504).json({ error: 'Gateway timeout' });
+        }
+    });
+    next();
+});
 app.use(rateLimit());
 
 // API routes

--- a/backend/src/config/stellar.ts
+++ b/backend/src/config/stellar.ts
@@ -15,11 +15,17 @@ const SOROBAN_RPC_URL =
 const NETWORK_PASSPHRASE =
   NETWORK === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
 
+export const STELLAR_REQUEST_TIMEOUT_MS = Number.parseInt(
+  process.env.STELLAR_REQUEST_TIMEOUT_MS || '15000',
+  10,
+);
+
 export const stellarConfig = {
   network: NETWORK,
   horizonUrl: HORIZON_URL,
   sorobanRpcUrl: SOROBAN_RPC_URL,
   networkPassphrase: NETWORK_PASSPHRASE,
+  requestTimeoutMs: STELLAR_REQUEST_TIMEOUT_MS,
 };
 
 export function getHorizonServer(): Horizon.Server {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,10 @@ import redisClient from "./config/redis";
 
 const app = express();
 const PORT = parseInt(process.env.PORT || "4000", 10);
+const RESPONSE_TIMEOUT_MS = Number.parseInt(
+  process.env.EXPRESS_RESPONSE_TIMEOUT_MS || "30000",
+  10,
+);
 
 // Trust proxy when behind reverse proxy/load balancer (nginx, Cloudflare, AWS ALB)
 // This ensures req.ip returns the real client IP from X-Forwarded-For header
@@ -49,6 +53,15 @@ app.use(
 );
 
 app.use(express.json({ limit: "10mb" }));
+app.use((req, res, next) => {
+  req.setTimeout(RESPONSE_TIMEOUT_MS);
+  res.setTimeout(RESPONSE_TIMEOUT_MS, () => {
+    if (!res.headersSent) {
+      res.status(504).json({ error: "Gateway timeout" });
+    }
+  });
+  next();
+});
 app.use(rateLimit());
 
 // API routes

--- a/backend/src/services/health.ts
+++ b/backend/src/services/health.ts
@@ -1,6 +1,6 @@
 import { checkDbConnection } from "../config/database";
 import redisClient from "../config/redis";
-import { getHorizonServer } from "../config/stellar";
+import { createHorizonServer } from "./horizon";
 import { getServer } from "./soroban-client";
 import { logger } from "../lib/logger";
 
@@ -31,7 +31,7 @@ export async function checkRedis(): Promise<"ok" | "error"> {
 
 export async function checkHorizon(): Promise<"ok" | "error"> {
   try {
-    const server = getHorizonServer();
+    const server = createHorizonServer();
     await server.feeStats();
     return "ok";
   } catch {

--- a/backend/src/services/horizon.ts
+++ b/backend/src/services/horizon.ts
@@ -1,12 +1,18 @@
 import { Horizon } from '@stellar/stellar-sdk';
-import { getHorizonServer } from '../config/stellar';
+import { getHorizonServer, STELLAR_REQUEST_TIMEOUT_MS } from '../config/stellar';
 import { logger } from '../lib/logger';
+
+export function createHorizonServer(): Horizon.Server {
+  const server = getHorizonServer();
+  server.httpClient.defaults.timeout = STELLAR_REQUEST_TIMEOUT_MS;
+  return server;
+}
 
 /**
  * Fetch account details from Horizon
  */
 export async function getAccountDetails(address: string) {
-  const server = getHorizonServer();
+  const server = createHorizonServer();
   try {
     const account = await server.loadAccount(address);
     const xlmBalance = account.balances.find((b: any) => b.asset_type === 'native');
@@ -28,7 +34,7 @@ export async function getAccountDetails(address: string) {
  * Get recent transactions for an account
  */
 export async function getAccountTransactions(address: string, limit = 20) {
-  const server = getHorizonServer();
+  const server = createHorizonServer();
   const result = await server
     .transactions()
     .forAccount(address)
@@ -45,7 +51,7 @@ export function streamLedgers(
   onLedger: (ledger: any) => void,
   onError?: (err: any) => void
 ): () => void {
-  const server = getHorizonServer();
+  const server = createHorizonServer();
   const es = server
     .ledgers()
     .cursor('now')
@@ -61,7 +67,7 @@ export function streamLedgers(
  * Get Stellar network fee stats
  */
 export async function getFeeStats() {
-  const server = getHorizonServer();
+  const server = createHorizonServer();
   return server.feeStats();
 }
 
@@ -69,7 +75,7 @@ export async function getFeeStats() {
  * Get operations for a contract account
  */
 export async function getContractOperations(contractId: string, limit = 50) {
-  const server = getHorizonServer();
+  const server = createHorizonServer();
   try {
     const result = await server
       .operations()

--- a/backend/src/services/soroban-client.ts
+++ b/backend/src/services/soroban-client.ts
@@ -8,13 +8,16 @@ import {
   xdr,
   Address,
 } from "@stellar/stellar-sdk";
-import { stellarConfig } from "../config/stellar";
+import { STELLAR_REQUEST_TIMEOUT_MS, stellarConfig } from "../config/stellar";
 
 const SIMULATION_ACCOUNT =
   "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
 
 export function getServer(): rpc.Server {
-  return new rpc.Server(stellarConfig.sorobanRpcUrl, { allowHttp: false });
+  return new rpc.Server(stellarConfig.sorobanRpcUrl, {
+    allowHttp: false,
+    timeout: STELLAR_REQUEST_TIMEOUT_MS,
+  });
 }
 
 /**


### PR DESCRIPTION
Closes #271 

Add timeouts for Stellar RPC and Horizon requests

Body:
add request timeouts for Soroban RPC and Horizon client calls
add Express response timeout middleware to return 504 on hung requests
apply the timeout handling in both backend app entrypoints and health checks

