### PR TITLE
fix: resolve issues #262 #261 #144 #215 — env mismatch, websocket tim…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,14 +12,19 @@ CORS_ORIGIN=http://localhost:3000
 JWT_SECRET=           # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 
 # Database (pg pool)
+# Docker Compose: credentials match docker-compose.yml / docker-compose.dev.yml
+# Local (no Docker): change DB_USER / DB_PASSWORD to your local PostgreSQL user
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=pulsartrack
-DB_USER=postgres
-DB_PASSWORD=
+DB_USER=pulsartrack
+DB_PASSWORD=pulsartrack_dev_password
 
 # Database (Prisma)
-DATABASE_URL=postgresql://postgres:@localhost:5432/pulsartrack
+# Docker Compose development (default):
+DATABASE_URL=postgresql://pulsartrack:pulsartrack_dev_password@localhost:5432/pulsartrack
+# Local development without Docker (uncomment and comment out the line above):
+# DATABASE_URL=postgresql://postgres:@localhost:5432/pulsartrack
 
 # Stellar / Soroban
 STELLAR_NETWORK=testnet

--- a/contracts/liquidity-pool/src/lib.rs
+++ b/contracts/liquidity-pool/src/lib.rs
@@ -177,6 +177,9 @@ impl LiquidityPoolContract {
             .get(&DataKey::TotalShares)
             .unwrap_or(0);
 
+        if total_shares == 0 {
+            panic!("no shares in pool");
+        }
         let amount = (shares * pool.total_liquidity) / total_shares;
         let available = pool.total_liquidity - pool.total_borrowed;
 
@@ -234,7 +237,9 @@ impl LiquidityPoolContract {
         }
 
         pool.total_borrowed += amount;
-        pool.utilization_rate = ((pool.total_borrowed * 100) / pool.total_liquidity) as u32;
+        if pool.total_liquidity > 0 {
+            pool.utilization_rate = ((pool.total_borrowed * 100) / pool.total_liquidity) as u32;
+        }
         pool.last_updated = env.ledger().timestamp();
         env.storage().instance().set(&DataKey::PoolState, &pool);
 

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -285,6 +285,39 @@ fn test_repay_partial_amount() {
 }
 
 #[test]
+#[should_panic(expected = "no shares in pool")]
+fn test_withdraw_when_total_shares_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _, _, token) = setup(&env);
+    let provider = Address::generate(&env);
+
+    // Deposit and then withdraw all shares so total_shares reaches 0
+    mint(&env, &token, &provider, 1_000_000);
+    let shares = c.deposit(&provider, &100_000i128);
+    c.withdraw(&provider, &shares);
+
+    // Pool now has total_shares == 0; attempting to withdraw 0 shares must panic
+    c.withdraw(&provider, &0i128);
+}
+
+#[test]
+fn test_borrow_utilization_rate_not_calculated_when_liquidity_zero() {
+    // When total_liquidity is 0, borrow() must not panic with division by zero.
+    // Any non-zero borrow amount is caught earlier by "insufficient liquidity",
+    // so we verify the borrow with amount=0 leaves utilization_rate unchanged.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _, _, _) = setup(&env);
+    let borrower = Address::generate(&env);
+
+    // No liquidity deposited; borrow 0 should succeed without dividing by zero
+    c.borrow(&borrower, &1u64, &0i128, &86_400u64);
+    let pool = c.get_pool_state();
+    assert_eq!(pool.utilization_rate, 0); // unchanged, no division attempted
+}
+
+#[test]
 fn test_accrue_interest() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/revenue-settlement/src/lib.rs
+++ b/contracts/revenue-settlement/src/lib.rs
@@ -11,7 +11,8 @@ pub struct RevenuePool {
     pub platform_share: i128,  // platform fee portion
     pub publisher_share: i128, // publisher earnings portion
     pub treasury_share: i128,  // DAO treasury portion
-    pub burn_amount: i128,     // tokens to burn
+    pub burn_amount: i128,     // tokens pending burn (cleared after each distribution)
+    pub total_burned: i128,    // cumulative tokens burned on-chain across all distributions
     pub platform_pct: u32,     // basis points
     pub publisher_pct: u32,
     pub treasury_pct: u32,
@@ -87,6 +88,7 @@ impl RevenueSettlementContract {
                 publisher_share: 0,
                 treasury_share: 0,
                 burn_amount: 0,
+                total_burned: 0,
                 platform_pct: 250,    // 2.5%
                 publisher_pct: 9_000, // 90%
                 treasury_pct: 500,    // 5%
@@ -223,6 +225,7 @@ impl RevenueSettlementContract {
         }
 
         if pool.burn_amount > 0 {
+            pool.total_burned += pool.burn_amount; // accumulate before resetting
             token_client.burn(&env.current_contract_address(), &pool.burn_amount);
             pool.burn_amount = 0;
         }

--- a/contracts/revenue-settlement/src/test.rs
+++ b/contracts/revenue-settlement/src/test.rs
@@ -60,6 +60,7 @@ fn test_initialize() {
 
     let pool = client.get_revenue_pool();
     assert_eq!(pool.total_revenue, 0);
+    assert_eq!(pool.total_burned, 0);
     assert_eq!(pool.platform_pct, 250);
     assert_eq!(pool.publisher_pct, 9_000);
     assert_eq!(pool.treasury_pct, 500);
@@ -199,12 +200,48 @@ fn test_distribute_platform_revenue() {
     assert_eq!(tc.balance(&treasury), 5_000); // treasury share
     assert_eq!(tc.balance(&contract_id), 9_990_000); // includes 2_500 burn from 10_000_000 funding
 
-    // Pool should be reset for platform, treasury, and burn
+    // Pool should be reset for platform, treasury, and burn; total_burned accumulates
     let pool = client.get_revenue_pool();
     assert_eq!(pool.platform_share, 0);
     assert_eq!(pool.treasury_share, 0);
     assert_eq!(pool.burn_amount, 0);
+    assert_eq!(pool.total_burned, 2_500); // 2.5% of 100_000 burned on-chain
     assert_eq!(pool.last_settlement, 1000);
+}
+
+#[test]
+fn test_total_burned_accumulates_across_distributions() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = deploy_token(&env, &token_admin);
+    let treasury = Address::generate(&env);
+    let platform = Address::generate(&env);
+
+    let contract_id = env.register_contract(None, RevenueSettlementContract);
+    let client = RevenueSettlementContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_addr, &treasury, &platform);
+    mint(&env, &token_addr, &contract_id, 10_000_000);
+
+    let publisher = Address::generate(&env);
+
+    // First distribution — burn 2_500 (2.5% of 100_000)
+    client.record_revenue(&admin, &1u64, &100_000i128, &publisher);
+    client.distribute_platform_revenue(&admin);
+
+    let pool_after_first = client.get_revenue_pool();
+    assert_eq!(pool_after_first.burn_amount, 0);   // cleared after burn
+    assert_eq!(pool_after_first.total_burned, 2_500); // recorded cumulatively
+
+    // Second distribution — burn another 2_500
+    client.record_revenue(&admin, &2u64, &100_000i128, &publisher);
+    client.distribute_platform_revenue(&admin);
+
+    let pool_after_second = client.get_revenue_pool();
+    assert_eq!(pool_after_second.burn_amount, 0);
+    assert_eq!(pool_after_second.total_burned, 5_000); // 2_500 + 2_500
 }
 
 #[test]

--- a/frontend/src/lib/websocket.ts
+++ b/frontend/src/lib/websocket.ts
@@ -67,11 +67,19 @@ class PulsarWebSocket {
   connect(): void {
     if (typeof window === 'undefined') return;
 
+    // Close any existing connection without triggering another reconnect cycle
+    if (this.ws) {
+      this.ws.onclose = null;
+      this.ws.close();
+      this.ws = null;
+    }
+
     try {
       this.ws = new WebSocket(this.url);
 
       this.ws.onopen = () => {
         this.reconnectAttempts = 0;
+        this.reconnectDelay = 3000; // reset backoff on successful connection
         this.emit({ type: 'connected', data: {}, timestamp: Date.now() });
       };
 
@@ -103,8 +111,15 @@ class PulsarWebSocket {
   private scheduleReconnect(): void {
     if (this.reconnectAttempts >= this.maxReconnectAttempts) return;
 
+    // Clear any pending timer before scheduling a new one to prevent accumulation
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+    }
+
     this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
       this.reconnectAttempts++;
+      this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000); // exponential backoff
       this.connect();
     }, this.reconnectDelay);
   }


### PR DESCRIPTION
closes #262 
closes #144 
closes #261 
closes #215 


backend/.env.example — DB credentials now match Docker Compose (pulsartrack / pulsartrack_dev_password). Includes a commented fallback for local non-Docker setup.
frontend/src/lib/websocket.ts — scheduleReconnect clears any pending timer before setting a new one, applies exponential backoff, and resets the delay on a successful connection. connect closes the existing socket before opening a new one to prevent multiple live connections.
contracts/liquidity-pool/src/lib.rs — Added zero-checks before divisions in withdraw (total_shares) and borrow (total_liquidity), with two new tests covering both cases.
contracts/revenue-settlement/src/lib.rs — Added total_burned: i128 to RevenuePool so cumulative on-chain burns are recorded rather than silently reset to zero after each distribution. Tests updated to assert the new field.