### PR TITLE
fix: validate max_daily_limit is positive in add_supported_chain

### DIFF
--- a/contracts/token-bridge/src/lib.rs
+++ b/contracts/token-bridge/src/lib.rs
@@ -84,6 +84,9 @@ impl TokenBridgeContract {
         if admin != stored_admin {
             panic!("unauthorized");
         }
+        if max_daily_limit <= 0 {
+            panic!("max_daily_limit must be positive");
+        }
         let _ttl_key = DataKey::SupportedChain(chain);
         env.storage().persistent().set(&_ttl_key, &max_daily_limit);
         env.storage().persistent().extend_ttl(

--- a/contracts/token-bridge/src/test.rs
+++ b/contracts/token-bridge/src/test.rs
@@ -65,6 +65,24 @@ fn test_add_supported_chain_unauthorized() {
 }
 
 #[test]
+#[should_panic(expected = "max_daily_limit must be positive")]
+fn test_add_supported_chain_zero_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    c.add_supported_chain(&admin, &s(&env, "ethereum"), &0i128);
+}
+
+#[test]
+#[should_panic(expected = "max_daily_limit must be positive")]
+fn test_add_supported_chain_negative_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    c.add_supported_chain(&admin, &s(&env, "ethereum"), &-1i128);
+}
+
+#[test]
 fn test_get_deposit_nonexistent() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary

  Fixes #297 — `add_supported_chain` in `contracts/token-bridge/src/lib.rs` accepted any `i128` value for
  `max_daily_limit` with no validation, causing two silent bugs in `deposit_for_bridge`:

  - `max_daily_limit = 0` → all transfers permanently blocked (`daily_vol + amount > 0` is always true)
  - `max_daily_limit < 0` → daily limit bypassed entirely (any positive amount passes the check)

  ## Changes

  **`contracts/token-bridge/src/lib.rs`**
  - Added a guard in `add_supported_chain` that panics with `"max_daily_limit must be positive"` if the value is `<= 0`

  **`contracts/token-bridge/src/test.rs`**
  - `test_add_supported_chain_zero_limit` — asserts zero is rejected
  - `test_add_supported_chain_negative_limit` — asserts negative values are rejected

  ## Affected Logic

  ```rust
  // Before — no validation, limit stored as-is
  pub fn add_supported_chain(env: Env, admin: Address, chain: String, max_daily_limit: i128) {
      ...
      env.storage().persistent().set(&_ttl_key, &max_daily_limit);
  }

  // After — validated before storage
  if max_daily_limit <= 0 {
      panic!("max_daily_limit must be positive");
  }

  Test Plan

  - test_add_supported_chain — valid positive limit still accepted
  - test_add_supported_chain_zero_limit — zero rejected with correct panic message
  - test_add_supported_chain_negative_limit — negative value rejected with correct panic message
  - test_add_supported_chain_unauthorized — unauthorized caller still rejected (no regression)
  
  Closes #297 