### PR TITLE
fix: Asymmetric Payout Arithmetic and Consistency Refactor

### DIFF
--- a/contracts/payout-automation/src/lib.rs
+++ b/contracts/payout-automation/src/lib.rs
@@ -96,12 +96,21 @@ impl PayoutAutomationContract {
             panic!("unauthorized");
         }
 
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let min_payout: i128 = env.storage().instance().get(&DataKey::MinPayoutAmount).unwrap_or(1_000_000);
+        if amount < min_payout {
+            panic!("amount below minimum payout");
+        }
+
         let counter: u64 = env
             .storage()
             .instance()
             .get(&DataKey::PayoutCounter)
             .unwrap_or(0);
-        let payout_id = counter + 1;
+        let payout_id = counter.checked_add(1).expect("counter overflow");
 
         let token_addr: Address = env
             .storage()
@@ -193,8 +202,14 @@ impl PayoutAutomationContract {
                     last_payout: 0,
                 });
 
-        earnings.total_paid += payout.amount;
-        earnings.pending_amount = earnings.pending_amount.saturating_sub(payout.amount);
+        earnings.total_paid = earnings
+            .total_paid
+            .checked_add(payout.amount)
+            .expect("total_paid overflow");
+        earnings.pending_amount = earnings
+            .pending_amount
+            .checked_sub(payout.amount)
+            .expect("insufficient pending earnings");
         earnings.last_payout = env.ledger().timestamp();
         env.storage().persistent().set(&key, &earnings);
         env.storage().persistent().extend_ttl(
@@ -231,7 +246,14 @@ impl PayoutAutomationContract {
                     last_payout: 0,
                 });
 
-        earnings.pending_amount += amount;
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        earnings.pending_amount = earnings
+            .pending_amount
+            .checked_add(amount)
+            .expect("pending_amount overflow");
         env.storage().persistent().set(&key, &earnings);
         env.storage().persistent().extend_ttl(
             &key,


### PR DESCRIPTION
Closes #307 

## Description

This PR resolves a critical inconsistency in the `payout-automation` contract where `total_paid` calculations were unchecked while `pending_amount` used saturating arithmetic ([#307](#307)). This asymmetry previously masked accounting bugs and could lead to silent data corruption or illogical contract states.

## Key Changes

- **Consistently Checked Arithmetic:** All financial state transitions for `PublisherEarnings` now use `checked_add` and `checked_sub` with explicit error handling.

- **Improved Diagnostics:** Updated the failure messages in `execute_payout` to correctly identify underflows in `pending_earnings`, facilitating better troubleshooting of upstream registry errors.

- **Entry-Point Hardening:** Added non-zero validation and minimum payout enforcement (reading from contract instance storage) to `schedule_payout` to prevent logic inversions.

- **Ledger Counter Safety:** Upgraded the `payout_id` sequence to a checked counter.