### PR TITLE
fix: wallet network mismatch, CPM formula, governance vote display, publisher race condition

### DIFF
--- a/backend/src/routes/publishers.ts
+++ b/backend/src/routes/publishers.ts
@@ -68,17 +68,17 @@ router.post('/register', requireAuth, validate({
     const address = req.stellarAddress;
     const { displayName, website } = req.body;
 
-    // Check if the address is already registered
-    const existing = await pool.query('SELECT id FROM publishers WHERE address = $1', [address]);
-    if (existing.rows.length > 0) {
-      return res.status(409).json({ error: 'Publisher already registered' });
-    }
-
     const { rows } = await pool.query(
       `INSERT INTO publishers (address, display_name, website)
-       VALUES ($1, $2, $3) RETURNING *`,
+       VALUES ($1, $2, $3)
+       ON CONFLICT (address) DO NOTHING
+       RETURNING *`,
       [address, displayName, website]
     );
+
+    if (rows.length === 0) {
+      return res.status(409).json({ error: 'Publisher already registered' });
+    }
 
     res.status(201).json(rows[0]);
   } catch (err: any) {

--- a/frontend/src/components/analytics/AnalyticsDashboard.tsx
+++ b/frontend/src/components/analytics/AnalyticsDashboard.tsx
@@ -28,7 +28,7 @@ export function AnalyticsDashboard({
 
   const rawCpm =
     totalImpressions > 0n
-      ? (Number(totalSpent) / Number(totalImpressions)) / 10000
+      ? (Number(totalSpent) / 1e7 / Number(totalImpressions)) * 1000
       : 0;
   const cpm = Number.isFinite(rawCpm) ? rawCpm.toFixed(4) : "0.0000";
 

--- a/frontend/src/components/governance/ProposalCard.tsx
+++ b/frontend/src/components/governance/ProposalCard.tsx
@@ -60,6 +60,12 @@ export function ProposalCard({ proposal, onVote, isVoting, userVote }: ProposalC
   const forPct = total > BigInt(0)
     ? ((Number(proposal.votes_for) / Number(total)) * 100).toFixed(1)
     : '0.0';
+  const againstPct = total > BigInt(0)
+    ? ((Number(proposal.votes_against) / Number(total)) * 100).toFixed(1)
+    : '0.0';
+  const abstainPct = total > BigInt(0)
+    ? ((Number(proposal.votes_abstain) / Number(total)) * 100).toFixed(1)
+    : '0.0';
   const isActive = proposal.status === 'Active';
   const deadline = new Date(Number(proposal.voting_ends_at) * 1000);
   const now = Date.now();
@@ -107,11 +113,8 @@ export function ProposalCard({ proposal, onVote, isVoting, userVote }: ProposalC
         <span className="text-gray-400">
           {Number(total).toLocaleString()} votes total
         </span>
-        <span className="text-red-400">
-          {total > BigInt(0)
-            ? (100 - parseFloat(forPct)).toFixed(1)
-            : '0.0'}% Against
-        </span>
+        <span className="text-red-400">{againstPct}% Against</span>
+        <span className="text-gray-500">{abstainPct}% Abstain</span>
       </div>
 
       {/* Footer */}

--- a/frontend/src/store/wallet-store.ts
+++ b/frontend/src/store/wallet-store.ts
@@ -50,7 +50,7 @@ export const useWalletStore = create<WalletStore>()(
 
           set({
             address: addr,
-            isConnected: !!addr,
+            isConnected: !!addr && isNetworkCorrect,
             freighterNetwork: freighterLabel,
             networkMismatch: !isNetworkCorrect && !!connected,
           });


### PR DESCRIPTION
## Summary

- **#322** — `isConnected` in `wallet-store.ts` now requires the network to be correct (`!!addr && isNetworkCorrect`), so protected features are properly disabled when the wallet is on the wrong network
- **#351** — CPM formula in `AnalyticsDashboard.tsx` rewritten as `(totalSpent / 1e7 / totalImpressions) * 1000` to correctly express cost-per-thousand impressions in XLM
- **#355** — `againstPct` and `abstainPct` in `ProposalCard.tsx` are now calculated independently from their respective vote counts instead of deriving against as `100 - forPct`, which was incorrectly folding abstain votes into the against total
- **#356** — Publisher registration in `publishers.ts` replaced the check-then-act pattern with an atomic `INSERT ... ON CONFLICT (address) DO NOTHING`, eliminating the race condition that allowed duplicate entries

## Test plan

- [ ] Connect Freighter on wrong network — app should show as disconnected, not just show mismatch banner
- [ ] Verify CPM metric reflects correct XLM cost per 1,000 impressions across campaigns
- [ ] Create a proposal with a mix of for/against/abstain votes — confirm all three percentages display correctly and sum to 100%
- [ ] Submit two concurrent publisher registration requests for the same address — confirm only one succeeds with a 409 on the second

Closes #322
Closes #351
Closes #355
Closes #356