### PR TITLE
fix(wallet): normalize seconds/ms timestamps in TxHistory.formatTimestamp

### DIFF
--- a/frontend/src/components/wallet/TxHistory.test.ts
+++ b/frontend/src/components/wallet/TxHistory.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeTimestampToMs } from './TxHistory';
+
+describe('normalizeTimestampToMs', () => {
+  it('treats values >= 1e12 as already milliseconds and returns them unchanged', () => {
+    const ms = 1_711_670_400_000; // 2024-03-28 in ms
+    expect(normalizeTimestampToMs(ms)).toBe(ms);
+  });
+
+  it('converts seconds (< 1e12) to milliseconds', () => {
+    const secs = 1_711_670_400; // 2024-03-28 in Unix seconds
+    expect(normalizeTimestampToMs(secs)).toBe(1_711_670_400_000);
+  });
+
+  it('never returns a 1970 date for a valid Stellar timestamp in seconds', () => {
+    const secs = 1_711_670_400;
+    const date = new Date(normalizeTimestampToMs(secs));
+    expect(date.getFullYear()).toBeGreaterThan(2000);
+  });
+
+  it('handles a timestamp at the boundary (exactly 1e12) as milliseconds', () => {
+    // 1e12 ms = year 2001; treat as ms (no conversion)
+    expect(normalizeTimestampToMs(1e12)).toBe(1e12);
+  });
+
+  it('handles a timestamp just below 1e12 as seconds', () => {
+    const justBelowBoundary = 999_999_999_999; // < 1e12 → seconds
+    expect(normalizeTimestampToMs(justBelowBoundary)).toBe(999_999_999_999_000);
+  });
+
+  it('round-trip: a recent Stellar seconds timestamp maps to a sensible ms date', () => {
+    const now = Math.floor(Date.now() / 1000); // current time in seconds
+    const ms = normalizeTimestampToMs(now);
+    const diff = Math.abs(Date.now() - ms);
+    // Should be within 1 second of actual now
+    expect(diff).toBeLessThan(1000);
+  });
+
+  it('normalises future timestamp in seconds correctly', () => {
+    // 1 year from a known epoch second
+    const futureSeconds = 1_800_000_000; // year ~2027
+    expect(normalizeTimestampToMs(futureSeconds)).toBe(1_800_000_000_000);
+  });
+});

--- a/frontend/src/components/wallet/TxHistory.tsx
+++ b/frontend/src/components/wallet/TxHistory.tsx
@@ -14,6 +14,14 @@ import { useTransactionStore, Transaction } from "../../store/tx-store";
 import { pollTransaction } from "../../lib/tx-recovery";
 import { getExplorerTxUrl } from "../../lib/stellar-config";
 
+/**
+ * Stellar blockchain timestamps are Unix seconds. JS Date/Date.now() use ms.
+ * Threshold 1e12: the year 2001 in ms — any value below that is seconds.
+ */
+export function normalizeTimestampToMs(timestamp: number): number {
+  return timestamp < 1e12 ? timestamp * 1000 : timestamp;
+}
+
 interface TxHistoryProps {
   isOpen: boolean;
   onClose: () => void;
@@ -75,9 +83,11 @@ export function TxHistory({ isOpen, onClose }: TxHistoryProps) {
   };
 
   const formatTimestamp = (timestamp: number) => {
-    const date = new Date(timestamp);
-    const now = Date.now();
-    const diff = now - timestamp;
+    // Stellar blockchain timestamps are Unix seconds; Date.now() is ms.
+    // Normalise: values below 1e12 are seconds, convert to ms.
+    const ms = normalizeTimestampToMs(timestamp);
+    const date = new Date(ms);
+    const diff = Date.now() - ms;
 
     // Less than 1 minute
     if (diff < 60000) return "Just now";


### PR DESCRIPTION
## Root Cause

Stellar blockchain timestamps are Unix **seconds**. `Date.now()` and `new Date(n)` expect **milliseconds**. `formatTimestamp` passed the raw value directly to `new Date(timestamp)` and computed `diff = Date.now() - timestamp`.

A Stellar timestamp like `1711670400` (seconds) is interpreted as 1.7 million ms — year **January 1970** — so `new Date(...)` renders `"1/20/1970"` and the diff is always massive, breaking all relative-time branches ("Just now", "m ago", "h ago", "d ago").

## Fix Approach

Extracted `normalizeTimestampToMs(timestamp: number): number` — a pure, exported function using the `< 1e12` threshold (safe boundary: year 2001 in ms = `~978_307_200_000`, well below `1e12`). Values below the threshold are seconds and are multiplied by 1000; values at or above pass through unchanged.

`formatTimestamp` now calls `normalizeTimestampToMs` before all date/diff operations. The function is exported so it can be unit-tested directly without component rendering.

## Edge Cases Handled

| Input | Interpretation | Output |
|-------|---------------|--------|
| `1_711_670_400` (seconds) | < 1e12 → multiply × 1000 | 2024 date |
| `1_711_670_400_000` (ms) | ≥ 1e12 → pass through | 2024 date |
| Exactly `1e12` | ≥ 1e12 → ms passthrough | year 2001 |
| `999_999_999_999` (just below 1e12) | < 1e12 → treated as seconds | year ~33658 |
| Current `Date.now() / 1000` | seconds → converts to ms diff ≈ 0 | "Just now" |

## Tests Added

7 unit tests in `TxHistory.test.ts` (pure function, no DOM needed):

- ms passthrough (≥ 1e12)
- seconds conversion (< 1e12)
- no 1970 dates for valid Stellar timestamps
- exact boundary (1e12)
- just-below boundary
- round-trip against current `Date.now()`
- future Stellar timestamp in seconds

Closes #375