### PR TITLE
fix(analytics): pass actual timeframe to useAnalyticsTimeseries; add '90d' type

### DIFF
--- a/frontend/src/components/analytics/AnalyticsDashboard.tsx
+++ b/frontend/src/components/analytics/AnalyticsDashboard.tsx
@@ -34,7 +34,7 @@ export function AnalyticsDashboard({
 
   const days = timeframe === "7d" ? 7 : timeframe === "30d" ? 30 : 90;
   const campaignIds = campaigns.map(c => c.campaign_id.toString());
-  const { data: timeseries, loading, error } = useAnalyticsTimeseries({ campaignIds, timeframe: days === 7 ? "7d" : "30d" });
+  const { data: timeseries, loading, error } = useAnalyticsTimeseries({ campaignIds, timeframe });
 
   return (
     <div className="space-y-6">

--- a/frontend/src/hooks/useAnalytics.test.ts
+++ b/frontend/src/hooks/useAnalytics.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAnalyticsTimeseries } from './useAnalytics';
+
+describe('useAnalyticsTimeseries', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('passes "7d" timeframe to the API URL', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    renderHook(() => useAnalyticsTimeseries({ campaignIds: ['1'], timeframe: '7d' }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain('timeframe=7d');
+    expect(url).not.toContain('timeframe=30d');
+  });
+
+  it('passes "30d" timeframe to the API URL', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    renderHook(() => useAnalyticsTimeseries({ campaignIds: ['1'], timeframe: '30d' }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain('timeframe=30d');
+    expect(url).not.toContain('timeframe=7d');
+    expect(url).not.toContain('timeframe=90d');
+  });
+
+  it('passes "90d" timeframe to the API URL — not silently replaced with "30d"', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    renderHook(() => useAnalyticsTimeseries({ campaignIds: ['1', '2'], timeframe: '90d' }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain('timeframe=90d');
+    expect(url).not.toContain('timeframe=30d');
+  });
+
+  it('includes all campaignIds in the query param', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    renderHook(() =>
+      useAnalyticsTimeseries({ campaignIds: ['10', '20', '30'], timeframe: '90d' })
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+
+    const url = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain('campaignIds=10,20,30');
+  });
+
+  it('sets error state on a non-OK response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => null,
+    } as Response);
+
+    const { result } = renderHook(() =>
+      useAnalyticsTimeseries({ campaignIds: ['1'], timeframe: '30d' })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('Failed to fetch analytics timeseries');
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/frontend/src/hooks/useAnalytics.ts
+++ b/frontend/src/hooks/useAnalytics.ts
@@ -8,7 +8,7 @@ export interface AnalyticsTimeseriesPoint {
 
 interface UseAnalyticsTimeseriesOptions {
   campaignIds: string[];
-  timeframe: '7d' | '30d';
+  timeframe: '7d' | '30d' | '90d';
 }
 
 export function useAnalyticsTimeseries({ campaignIds, timeframe }: UseAnalyticsTimeseriesOptions) {


### PR DESCRIPTION
## Root Cause

`AnalyticsDashboard.tsx` computed `days` from the selected `timeframe` prop:
```ts
const days = timeframe === "7d" ? 7 : timeframe === "30d" ? 30 : 90;
```
Then immediately discarded it when calling the hook:
```ts
timeframe: days === 7 ? "7d" : "30d"  // "90d" → "30d" silently
```
Selecting the 90-day tab sent `timeframe=30d` to the API. Users saw 30-day data under a "Last 90 Days" heading — a silent, misleading data mismatch with no error or indication.

Additionally, `UseAnalyticsTimeseriesOptions.timeframe` was typed `'7d' | '30d'`, which made the TypeScript compiler actively prevent `'90d'` from being passed even after a direct fix.

## Fix Approach

1. **`useAnalytics.ts`**: Extended the `timeframe` union to `'7d' | '30d' | '90d'`. The API fetch URL passes the value verbatim, so no further changes needed in the hook body.
2. **`AnalyticsDashboard.tsx`**: Replaced the re-derived timeframe expression with `timeframe` directly. `days` is kept unchanged for the "Last {days} Days" heading label.

## Edge Cases Handled

- `timeframe` defaults to `"30d"` if unset — no change to this behaviour.
- `days` variable is still computed for the UI label; it is no longer involved in the hook call.
- The TypeScript type change is a strict widening (additive), causing no regressions.

## Tests Added

5 unit tests in `useAnalytics.test.ts` mocking `fetch`:

| Test | Verifies |
|------|---------|
| `7d` URL | `?timeframe=7d` present, not `30d` |
| `30d` URL | `?timeframe=30d` present, not `7d` or `90d` |
| `90d` URL | `?timeframe=90d` present, **not `30d`** (the regression case) |
| Campaign IDs | All IDs appear in `?campaignIds=` |
| Error state | Non-OK response sets `error`, `data=[]`, `loading=false` |

Closes #352