### PR TITLE
fix(subscription): replace daysLeft===0 expiry check with direct timestamp compare

### DIFF
--- a/frontend/src/components/subscription/SubscriptionStatus.test.tsx
+++ b/frontend/src/components/subscription/SubscriptionStatus.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SubscriptionStatus } from './SubscriptionStatus';
+import { Subscription } from '@/types/contracts';
+
+const NOW_MS = 1_714_000_000_000; // fixed "now" for deterministic tests
+const NOW_S = Math.floor(NOW_MS / 1000);
+
+function makeSubscription(expiresOffsetMs: number): Subscription {
+  const expiresS = BigInt(Math.floor((NOW_MS + expiresOffsetMs) / 1000));
+  return {
+    subscriber: 'GABC...123',
+    tier: 'Growth',
+    is_annual: false,
+    amount_paid: 50_000_000n, // 5 XLM in stroops
+    started_at: BigInt(NOW_S - 2_592_000), // 30 days ago
+    expires_at: expiresS,
+    auto_renew: true,
+    campaigns_used: 2,
+    impressions_used: 10_000n,
+  };
+}
+
+describe('SubscriptionStatus expiry logic', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows "Expired" for a subscription that expired 2 days ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+
+    const sub = makeSubscription(-2 * 86_400_000); // expired 2 days ago
+    render(<SubscriptionStatus subscription={sub} />);
+    expect(screen.getByText('Expired')).toBeDefined();
+  });
+
+  it('shows "Expired" for a subscription that expired 1ms ago', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+
+    const sub = makeSubscription(-1);
+    render(<SubscriptionStatus subscription={sub} />);
+    expect(screen.getByText('Expired')).toBeDefined();
+  });
+
+  it('shows days remaining for a subscription expiring in 3 days', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+
+    const sub = makeSubscription(3 * 86_400_000);
+    render(<SubscriptionStatus subscription={sub} />);
+    expect(screen.getByText('3 days left')).toBeDefined();
+  });
+
+  it('shows days remaining for a subscription expiring today (5 hours left)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+
+    const sub = makeSubscription(5 * 3_600_000); // 5 hours remaining
+    render(<SubscriptionStatus subscription={sub} />);
+    // Math.ceil(5h / 24h) = 1
+    expect(screen.getByText('1 days left')).toBeDefined();
+  });
+
+  it('shows the expiry date (not a warning) for a subscription with > 7 days left', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+
+    const sub = makeSubscription(30 * 86_400_000);
+    render(<SubscriptionStatus subscription={sub} />);
+    // Should render the formatted expiry date, not "Expired" or "X days left"
+    expect(screen.queryByText('Expired')).toBeNull();
+    expect(screen.queryByText(/days left/)).toBeNull();
+  });
+
+  it('isExpired and isExpiringSoon are mutually exclusive — expired sub shows Renew, not Cancel', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+
+    const sub = makeSubscription(-1 * 86_400_000); // expired yesterday
+    const onRenew = vi.fn();
+    const onCancel = vi.fn();
+    render(<SubscriptionStatus subscription={sub} onRenew={onRenew} onCancel={onCancel} />);
+
+    expect(screen.getByRole('button', { name: 'Renew' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+  });
+
+  it('renders null subscription with "No active subscription" message', () => {
+    render(<SubscriptionStatus subscription={null} />);
+    expect(screen.getByText('No active subscription')).toBeDefined();
+  });
+});

--- a/frontend/src/components/subscription/SubscriptionStatus.tsx
+++ b/frontend/src/components/subscription/SubscriptionStatus.tsx
@@ -26,11 +26,12 @@ export function SubscriptionStatus({ subscription, onCancel, onRenew }: Subscrip
     );
   }
 
-  const expiresDate = new Date(Number(subscription.expires_at) * 1000);
   const now = Date.now();
-  const daysLeft = Math.max(0, Math.floor((Number(subscription.expires_at) * 1000 - now) / 86400000));
-  const isExpiringSoon = daysLeft <= 7 && daysLeft > 0;
-  const isExpired = daysLeft === 0;
+  const expiresMs = Number(subscription.expires_at) * 1000;
+  const expiresDate = new Date(expiresMs);
+  const isExpired = expiresMs <= now;
+  const daysLeft = isExpired ? 0 : Math.ceil((expiresMs - now) / 86400000);
+  const isExpiringSoon = !isExpired && daysLeft <= 7;
   const tierStyle = TIER_COLORS[subscription.tier] || TIER_COLORS.Starter;
   const pricePaid = (Number(subscription.amount_paid) / 1e7).toFixed(2);
 


### PR DESCRIPTION
## Root Cause

The original logic derived `daysLeft` with `Math.max(0, Math.floor(...))`, clamping any negative value to `0`. This meant:

- A subscription expired **30 days ago** → `daysLeft === 0`
- A subscription expiring in **5 hours** → `daysLeft === 0` (floor of 0.2 = 0)

Both cases produced `isExpired = (daysLeft === 0) = true`, and neither was caught by `isExpiringSoon = (daysLeft <= 7 && daysLeft > 0)` — the `> 0` guard excluded the expiring-today case.

The result: a subscription expiring in 5 hours was neither "expiring soon" nor visually "expired" — it fell into an indeterminate UI state where the user received no warning and the `Cancel` button was hidden (via `!isExpired`) while `Renew` was also hidden (via `isExpiringSoon`).

## Fix Approach

Replaced the clamped `daysLeft` derivation with a direct timestamp comparison:

```ts
const expiresMs = Number(subscription.expires_at) * 1000;
const isExpired = expiresMs <= now;                                    // source of truth
const daysLeft = isExpired ? 0 : Math.ceil((expiresMs - now) / 86400000);
const isExpiringSoon = !isExpired && daysLeft <= 7;
```

Key decisions:
- **`Math.ceil`**: A subscription expiring in 5 hours shows `daysLeft=1`, not 0. This avoids triggering the expired state prematurely while still displaying a meaningful countdown.
- **`!isExpired` guard on `isExpiringSoon`**: Ensures the three states (expired / expiring soon / active) are mutually exclusive, preventing double-rendering of action buttons.

## Edge Cases Handled

| Scenario | `isExpired` | `daysLeft` | `isExpiringSoon` | UI |
|----------|-------------|------------|------------------|----|
| Expired 2 days ago | `true` | `0` | `false` | "Expired" + Renew |
| Expired 1ms ago | `true` | `0` | `false` | "Expired" + Renew |
| Expiring in 5 hours | `false` | `1` | `true` | "1 days left" + Renew + Cancel |
| Expiring in 3 days | `false` | `3` | `true` | "3 days left" + Renew + Cancel |
| Active, 30 days left | `false` | `30` | `false` | date + Cancel only |

## Tests Added

7 unit tests in `SubscriptionStatus.test.tsx` (using `vi.useFakeTimers`):

1. Expired 2 days ago → shows "Expired"
2. Expired 1ms ago → shows "Expired" (boundary)
3. Expiring in 3 days → shows "3 days left"
4. Expiring in 5 hours → shows "1 days left" (Math.ceil)
5. Active > 7 days → no "Expired" or "X days left"
6. Expired → Renew shown, Cancel hidden (mutual exclusion)
7. `subscription === null` → "No active subscription"

Closes #353