### PR TITLE
Fix targeting submit, campaign parsing, and analytics auth

### DIFF
--- a/contracts/analytics-aggregator/src/lib.rs
+++ b/contracts/analytics-aggregator/src/lib.rs
@@ -54,6 +54,19 @@ const INSTANCE_BUMP_AMOUNT: u32 = 86_400;
 const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
 const PERSISTENT_BUMP_AMOUNT: u32 = 1_051_200;
 
+fn require_oracle(env: &Env, caller: &Address) {
+    caller.require_auth();
+    let stored_oracle: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::OracleAddress)
+        .expect("oracle not set");
+
+    if caller != &stored_oracle {
+        panic!("only oracle can record analytics");
+    }
+}
+
 #[contract]
 pub struct AnalyticsAggregatorContract;
 
@@ -86,12 +99,7 @@ impl AnalyticsAggregatorContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
-        let _stored_oracle: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::OracleAddress)
-            .unwrap();
-        caller.require_auth();
+        require_oracle(&env, &caller);
 
         let mut analytics: CampaignAnalytics = env
             .storage()
@@ -161,7 +169,7 @@ impl AnalyticsAggregatorContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
-        caller.require_auth();
+        require_oracle(&env, &caller);
 
         let mut analytics: CampaignAnalytics = env
             .storage()

--- a/contracts/analytics-aggregator/src/test.rs
+++ b/contracts/analytics-aggregator/src/test.rs
@@ -2,13 +2,13 @@
 use super::*;
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
-fn setup(env: &Env) -> (AnalyticsAggregatorContractClient<'_>, Address) {
+fn setup(env: &Env) -> (AnalyticsAggregatorContractClient<'_>, Address, Address) {
     let admin = Address::generate(env);
     let oracle = Address::generate(env);
     let id = env.register_contract(None, AnalyticsAggregatorContract);
     let c = AnalyticsAggregatorContractClient::new(env, &id);
     c.initialize(&admin, &oracle);
-    (c, admin)
+    (c, admin, oracle)
 }
 
 #[test]
@@ -44,9 +44,8 @@ fn test_initialize_non_admin_fails() {
 fn test_record_impression() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, _) = setup(&env);
-    let caller = Address::generate(&env);
-    c.record_impression(&caller, &1u64, &100i128);
+    let (c, _, oracle) = setup(&env);
+    c.record_impression(&oracle, &1u64, &100i128);
     let a = c.get_campaign_analytics(&1u64).unwrap();
     assert_eq!(a.total_impressions, 1);
 }
@@ -55,19 +54,41 @@ fn test_record_impression() {
 fn test_record_click() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, _) = setup(&env);
-    let caller = Address::generate(&env);
-    c.record_impression(&caller, &1u64, &100i128);
-    c.record_click(&caller, &1u64);
+    let (c, _, oracle) = setup(&env);
+    c.record_impression(&oracle, &1u64, &100i128);
+    c.record_click(&oracle, &1u64);
     let a = c.get_campaign_analytics(&1u64).unwrap();
     assert_eq!(a.total_clicks, 1);
+}
+
+#[test]
+#[should_panic(expected = "only oracle can record analytics")]
+fn test_record_impression_rejects_non_oracle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _, _) = setup(&env);
+    let caller = Address::generate(&env);
+
+    c.record_impression(&caller, &1u64, &100i128);
+}
+
+#[test]
+#[should_panic(expected = "only oracle can record analytics")]
+fn test_record_click_rejects_non_oracle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _, oracle) = setup(&env);
+    let caller = Address::generate(&env);
+
+    c.record_impression(&oracle, &1u64, &100i128);
+    c.record_click(&caller, &1u64);
 }
 
 #[test]
 fn test_get_campaign_analytics_nonexistent() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, _) = setup(&env);
+    let (c, _, _) = setup(&env);
     assert!(c.get_campaign_analytics(&999u64).is_none());
 }
 
@@ -75,7 +96,7 @@ fn test_get_campaign_analytics_nonexistent() {
 fn test_get_global_stats() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, _) = setup(&env);
+    let (c, _, _) = setup(&env);
     let stats = c.get_global_stats();
     assert_eq!(stats.total_campaigns, 0);
 }
@@ -84,11 +105,11 @@ fn test_get_global_stats() {
 fn test_record_conversion_increments_count() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, _) = setup(&env);
+    let (c, _, oracle) = setup(&env);
     let caller = Address::generate(&env);
 
-    c.record_impression(&caller, &1u64, &100i128);
-    c.record_click(&caller, &1u64);
+    c.record_impression(&oracle, &1u64, &100i128);
+    c.record_click(&oracle, &1u64);
     c.record_conversion(&caller, &1u64);
 
     let a = c.get_campaign_analytics(&1u64).unwrap();
@@ -99,15 +120,15 @@ fn test_record_conversion_increments_count() {
 fn test_record_conversion_calculates_cvr() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, _) = setup(&env);
+    let (c, _, oracle) = setup(&env);
     let caller = Address::generate(&env);
 
     // 4 impressions, 2 clicks, 1 conversion → cvr = 1/2 * 10000 = 5000
     for _ in 0..4 {
-        c.record_impression(&caller, &1u64, &100i128);
+        c.record_impression(&oracle, &1u64, &100i128);
     }
-    c.record_click(&caller, &1u64);
-    c.record_click(&caller, &1u64);
+    c.record_click(&oracle, &1u64);
+    c.record_click(&oracle, &1u64);
     c.record_conversion(&caller, &1u64);
 
     let a = c.get_campaign_analytics(&1u64).unwrap();
@@ -118,11 +139,10 @@ fn test_record_conversion_calculates_cvr() {
 fn test_cvr_stays_zero_without_clicks() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, _) = setup(&env);
-    let caller = Address::generate(&env);
+    let (c, _, oracle) = setup(&env);
 
     // Impressions but no clicks — cvr guard prevents divide-by-zero
-    c.record_impression(&caller, &1u64, &100i128);
+    c.record_impression(&oracle, &1u64, &100i128);
 
     // Manually set total_conversions via record_conversion requires a click first;
     // here we just confirm cvr is 0 without any clicks
@@ -135,7 +155,7 @@ fn test_cvr_stays_zero_without_clicks() {
 fn test_record_conversion_without_analytics_panics() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, _) = setup(&env);
+    let (c, _, _) = setup(&env);
     let caller = Address::generate(&env);
 
     c.record_conversion(&caller, &999u64);

--- a/contracts/analytics-aggregator/test_snapshots/test/test_cvr_stays_zero_without_clicks.1.json
+++ b/contracts/analytics-aggregator/test_snapshots/test/test_cvr_stays_zero_without_clicks.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 4,
+    "address": 3,
     "nonce": 0
   },
   "auth": [
@@ -29,7 +29,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -37,7 +37,7 @@
               "function_name": "record_impression",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -89,6 +89,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",
@@ -430,39 +463,6 @@
             "ext": "v0"
           },
           86400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
         ]
       ],
       [

--- a/contracts/analytics-aggregator/test_snapshots/test/test_record_click_rejects_non_oracle.1.json
+++ b/contracts/analytics-aggregator/test_snapshots/test/test_record_click_rejects_non_oracle.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0
   },
   "auth": [
@@ -55,28 +55,6 @@
         }
       ]
     ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "function_name": "record_click",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "u64": 1
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
     []
   ],
   "ledger": {
@@ -111,39 +89,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
                   }
                 },
                 "durability": "temporary",
@@ -249,7 +194,7 @@
                         "symbol": "ctr"
                       },
                       "val": {
-                        "u32": 10000
+                        "u32": 0
                       }
                     },
                     {
@@ -273,7 +218,7 @@
                         "symbol": "total_clicks"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 0
                       }
                     },
                     {
@@ -473,7 +418,7 @@
                                 "symbol": "total_clicks"
                               },
                               "val": {
-                                "u64": 1
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/analytics-aggregator/test_snapshots/test/test_record_conversion_calculates_cvr.1.json
+++ b/contracts/analytics-aggregator/test_snapshots/test/test_record_conversion_calculates_cvr.1.json
@@ -29,7 +29,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -37,7 +37,7 @@
               "function_name": "record_impression",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -57,7 +57,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -65,7 +65,7 @@
               "function_name": "record_impression",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -85,7 +85,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -93,7 +93,7 @@
               "function_name": "record_impression",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -113,7 +113,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -121,7 +121,7 @@
               "function_name": "record_impression",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -141,7 +141,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -149,7 +149,7 @@
               "function_name": "record_click",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -163,7 +163,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -171,7 +171,7 @@
               "function_name": "record_click",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -239,6 +239,204 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 8370022561469687789
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 8370022561469687789
                   }
                 },
                 "durability": "temporary",
@@ -588,171 +786,6 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 2032731177588607455
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 2032731177588607455
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 4270020994084947596
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 4270020994084947596
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 4837995959683129791
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 4837995959683129791
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
                 "nonce": 6277191135259896685
               }
             },
@@ -769,39 +802,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 6277191135259896685
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 8370022561469687789
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 8370022561469687789
                   }
                 },
                 "durability": "temporary",

--- a/contracts/analytics-aggregator/test_snapshots/test/test_record_conversion_increments_count.1.json
+++ b/contracts/analytics-aggregator/test_snapshots/test/test_record_conversion_increments_count.1.json
@@ -29,7 +29,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -37,7 +37,7 @@
               "function_name": "record_impression",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -57,7 +57,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -65,7 +65,7 @@
               "function_name": "record_click",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -133,6 +133,72 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",
@@ -482,39 +548,6 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
                 "nonce": 4837995959683129791
               }
             },
@@ -531,39 +564,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 4837995959683129791
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/contracts/analytics-aggregator/test_snapshots/test/test_record_impression.1.json
+++ b/contracts/analytics-aggregator/test_snapshots/test/test_record_impression.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 4,
+    "address": 3,
     "nonce": 0
   },
   "auth": [
@@ -29,7 +29,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -37,7 +37,7 @@
               "function_name": "record_impression",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -89,6 +89,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",
@@ -430,39 +463,6 @@
             "ext": "v0"
           },
           86400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
         ]
       ],
       [

--- a/contracts/analytics-aggregator/test_snapshots/test/test_record_impression_rejects_non_oracle.1.json
+++ b/contracts/analytics-aggregator/test_snapshots/test/test_record_impression_rejects_non_oracle.1.json
@@ -1,0 +1,212 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "GlobalStats"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "last_updated"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_campaigns"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_clicks"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_impressions"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "total_spend"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "OracleAddress"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          86400
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          86400
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/frontend/src/components/campaign/CampaignForm.test.tsx
+++ b/frontend/src/components/campaign/CampaignForm.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { CampaignForm } from './CampaignForm';
+import { CampaignForm, parseCampaignSubmission } from './CampaignForm';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useCreateCampaign } from '@/hooks/useContract';
 
@@ -43,7 +43,7 @@ describe('CampaignForm', () => {
             target: { value: '100' },
         });
 
-        mockCreateCampaign.mockResolvedValue(1); // Returns campaign ID
+        mockCreateCampaign.mockResolvedValue({ success: true, result: 1 });
 
         fireEvent.click(screen.getByText('Create Campaign'));
 
@@ -54,6 +54,23 @@ describe('CampaignForm', () => {
                 budgetXlm: 100,
             }));
             expect(mockOnSuccess).toHaveBeenCalledWith(1);
+        });
+    });
+
+    it('should reject non-finite numeric values before contract submission', () => {
+        expect(parseCampaignSubmission({
+            title: 'Overflow Campaign',
+            contentId: 'ipfs://overflow',
+            campaignType: 1,
+            budgetXlm: '1e309',
+            costPerViewXlm: '0.001',
+            durationDays: 30,
+            targetViews: '10000',
+            dailyViewLimit: '1000',
+            refundable: true,
+        })).toEqual({
+            ok: false,
+            error: 'Invalid numeric values',
         });
     });
 

--- a/frontend/src/components/campaign/CampaignForm.tsx
+++ b/frontend/src/components/campaign/CampaignForm.tsx
@@ -11,6 +11,53 @@ interface CampaignFormProps {
   onCancel?: () => void;
 }
 
+type CampaignSubmission =
+  | { ok: false; error: string }
+  | {
+      ok: true;
+      payload: {
+        title: string;
+        contentId: string;
+        campaignType: number;
+        budgetXlm: number;
+        costPerViewXlm: number;
+        durationDays: number;
+        targetViews: number;
+        dailyViewLimit: number;
+        refundable: boolean;
+      };
+    };
+
+export function parseCampaignSubmission(
+  data: CampaignFormData,
+): CampaignSubmission {
+  const budget = Number.parseFloat(data.budgetXlm);
+  const costPerView = Number.parseFloat(data.costPerViewXlm);
+  const campaignType = Number(data.campaignType);
+  const durationDays = Number(data.durationDays);
+  const targetViews = Number.parseInt(data.targetViews, 10);
+  const dailyViewLimit = Number.parseInt(data.dailyViewLimit, 10);
+
+  if (!Number.isFinite(budget) || !Number.isFinite(costPerView)) {
+    return { ok: false, error: "Invalid numeric values" };
+  }
+
+  return {
+    ok: true,
+    payload: {
+      title: data.title,
+      contentId: data.contentId,
+      campaignType,
+      budgetXlm: budget,
+      costPerViewXlm: costPerView,
+      durationDays,
+      targetViews,
+      dailyViewLimit,
+      refundable: data.refundable ?? true,
+    },
+  };
+}
+
 export function CampaignForm({ onSuccess, onCancel }: CampaignFormProps) {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const { createCampaign, isPending } = useCreateCampaign();
@@ -50,18 +97,25 @@ export function CampaignForm({ onSuccess, onCancel }: CampaignFormProps) {
     setSubmitError(null);
 
     try {
-      const result = await createCampaign({
-        title: data.title,
-        contentId: data.contentId,
-        campaignType: data.campaignType as number,
-        budgetXlm: parseFloat(data.budgetXlm),
-        costPerViewXlm: parseFloat(data.costPerViewXlm),
-        durationDays: data.durationDays as number,
-        targetViews: parseInt(data.targetViews),
-        dailyViewLimit: parseInt(data.dailyViewLimit),
-        refundable: data.refundable ?? true,
-      });
-      onSuccess?.(result as unknown as number);
+      const submission = parseCampaignSubmission(data);
+
+      if (!submission.ok) {
+        setSubmitError(submission.error);
+        return;
+      }
+
+      const result = await createCampaign(submission.payload);
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to create campaign");
+      }
+
+      const campaignId = Number(result.result);
+      if (!Number.isSafeInteger(campaignId) || campaignId <= 0) {
+        throw new Error("Invalid campaign ID returned");
+      }
+
+      onSuccess?.(campaignId);
       reset();
     } catch (err: any) {
       setSubmitError(err?.message || "Failed to create campaign");

--- a/frontend/src/components/targeting/TargetingForm.test.tsx
+++ b/frontend/src/components/targeting/TargetingForm.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TargetingForm } from './TargetingForm';
+
+describe('TargetingForm', () => {
+    it('prevents duplicate submissions while a save is pending', async () => {
+        let resolveSave: (() => void) | undefined;
+        const onSave = vi.fn(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveSave = resolve;
+                }),
+        );
+
+        render(<TargetingForm onSave={onSave} />);
+
+        fireEvent.change(screen.getByLabelText(/Min Age/i), {
+            target: { value: '21' },
+        });
+
+        const submitButton = await screen.findByRole('button', {
+            name: /Save Targeting Settings/i,
+        });
+
+        fireEvent.click(submitButton);
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+
+        expect(screen.getByRole('button', { name: /Saving\.\.\./i })).toBeDisabled();
+
+        resolveSave?.();
+
+        await waitFor(() => {
+            expect(screen.getByText(/Targeting settings saved!/i)).toBeInTheDocument();
+        });
+    });
+});

--- a/frontend/src/components/targeting/TargetingForm.tsx
+++ b/frontend/src/components/targeting/TargetingForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { SegmentGroup } from './AudienceSegmentTag';
@@ -51,6 +51,8 @@ const DEFAULT_CONFIG: TargetingConfig = {
 export function TargetingForm({ initial, onSave, isSaving }: TargetingFormProps) {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
+  const [isPending, setIsPending] = useState(false);
+  const submitLockedRef = useRef(false);
 
   const {
     register,
@@ -69,6 +71,7 @@ export function TargetingForm({ initial, onSave, isSaving }: TargetingFormProps)
   const excludedSegments = watch('excludedSegments');
   const devices = watch('devices');
   const languages = watch('languages');
+  const isSubmitting = Boolean(isSaving) || isPending;
 
   const addTo = (field: 'regions' | 'interests' | 'excludedSegments' | 'devices' | 'languages') =>
     (val: string) => {
@@ -83,13 +86,23 @@ export function TargetingForm({ initial, onSave, isSaving }: TargetingFormProps)
     };
 
   const onSubmit = async (data: TargetingFormData) => {
+    if (Boolean(isSaving) || submitLockedRef.current) {
+      return;
+    }
+
+    submitLockedRef.current = true;
+    setIsPending(true);
     setSubmitError(null);
+
     try {
       await onSave?.(data as TargetingConfig);
       setSaved(true);
       setTimeout(() => setSaved(false), 3000);
     } catch (err: any) {
       setSubmitError(err?.message || 'Failed to save targeting settings');
+    } finally {
+      submitLockedRef.current = false;
+      setIsPending(false);
     }
   };
 
@@ -256,10 +269,10 @@ export function TargetingForm({ initial, onSave, isSaving }: TargetingFormProps)
 
       <button
         type="submit"
-        disabled={!isValid || isSaving}
+        disabled={!isValid || isSubmitting}
         className="w-full bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium py-2 px-4 rounded-lg transition-colors text-sm"
       >
-        {isSaving ? 'Saving...' : 'Save Targeting Settings'}
+        {isSubmitting ? 'Saving...' : 'Save Targeting Settings'}
       </button>
     </form>
   );


### PR DESCRIPTION
## Summary

- Fixes the `TargetingForm` double-submit path by adding a local pending guard and submit-state UI (`#324`)
- Validates parsed numeric campaign inputs and verifies the returned campaign ID before calling `onSuccess` (`#325`)
- Enforces stored-oracle authorization for analytics impression and click writes, with regression coverage (`#296`)
- References `#329`: no code change was needed in this branch because `backend/src/api/routes.ts` already mounts `governanceRoutes` at `/governance` on the current `main`

## Testing

- `cargo test -p pulsar-analytics-aggregator`
- `npx vitest run --config .tmp-vitest.config.mjs src/components/campaign/CampaignForm.test.tsx src/components/targeting/TargetingForm.test.tsx`

## Linked Issues

- Fixes #324
- Fixes #325
- Fixes #296
- Refs #329
