### PR TITLE
Fix write rate limiting, test assertions, escrow event docs, and deploy record handling

### DIFF
--- a/backend/src/routes/auctions.ts
+++ b/backend/src/routes/auctions.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express";
 import pool from "../config/database";
 import { callReadOnly } from "../services/soroban-client";
 import { CONTRACT_IDS } from "../config/stellar";
-import { requireAuth } from "../middleware/auth";
+import { requireAuth, rateLimitWrite } from "../middleware/auth";
 import { validate } from "../middleware/validate";
 
 const router = Router();
@@ -84,12 +84,13 @@ router.get(
 );
 
 router.post(
-  "/:auctionId/bid",
-  requireAuth,
-  validate({
-    params: {
-      auctionId: { type: "number", required: true, integer: true, min: 1 },
-    },
+	"/:auctionId/bid",
+	requireAuth,
+	rateLimitWrite(),
+	validate({
+	  params: {
+	    auctionId: { type: "number", required: true, integer: true, min: 1 },
+	  },
     body: {
       campaignId: { type: "number", required: true, integer: true, min: 1 },
       amountStroops: { type: "number", required: true, integer: true, min: 1 },

--- a/backend/src/routes/campaigns.ts
+++ b/backend/src/routes/campaigns.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from 'express';
 import pool from '../config/database';
 import { callReadOnly } from '../services/soroban-client';
 import { CONTRACT_IDS } from '../config/stellar';
-import { requireAuth } from '../middleware/auth';
+import { requireAuth, rateLimitWrite } from '../middleware/auth';
 import { validate } from '../middleware/validate';
 
 const router = Router();
@@ -47,7 +47,7 @@ router.get('/stats', async (_req: Request, res: Response) => {
   }
 });
 
-router.post('/', requireAuth, validate({
+router.post('/', requireAuth, rateLimitWrite(), validate({
   body: {
     title: { type: 'string', required: true, minLength: 1, maxLength: 200 },
     contentId: { type: 'string', required: true, minLength: 1 },

--- a/backend/src/routes/publishers.ts
+++ b/backend/src/routes/publishers.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express";
 import pool from "../config/database";
 import { callReadOnly, toAddressScVal } from "../services/soroban-client";
 import { CONTRACT_IDS } from "../config/stellar";
-import { requireAuth } from "../middleware/auth";
+import { requireAuth, rateLimitWrite } from "../middleware/auth";
 import { validate } from "../middleware/validate";
 
 const router = Router();
@@ -70,12 +70,13 @@ router.get(
 );
 
 router.post(
-  "/register",
-  requireAuth,
-  validate({
-    body: {
-      displayName: {
-        type: "string",
+	"/register",
+	requireAuth,
+	rateLimitWrite(),
+	validate({
+	  body: {
+	    displayName: {
+	      type: "string",
         required: true,
         minLength: 1,
         maxLength: 100,

--- a/contracts/escrow-vault/src/lib.rs
+++ b/contracts/escrow-vault/src/lib.rs
@@ -4,7 +4,7 @@
 //! Events:
 //! - ("escrow", "created"): [escrow_id: u64, campaign_id: u64, amount: i128]
 //! - ("escrow", "release"): [escrow_id: u64, amount: i128]
-//! - ("escrow", "release_partial"): [escrow_id: u64, amount: i128]
+//! - ("escrow", "release_p"): [escrow_id: u64, amount: i128]
 //! - ("escrow", "refund"): [escrow_id: u64, amount: i128]
 
 #![no_std]

--- a/deployments/deployed-testnet.json
+++ b/deployments/deployed-testnet.json
@@ -1,6 +1,6 @@
 {
   "network": "testnet",
-  "deployer": "DRY_RUN_ADDRESS",
+  "deployer": "",
   "contracts": {
     "ad_registry": "CBA3AA7OV4WPZ56JDAL5JGMARAFLYCTDGLI3SF5CWNLSG3QSWBAB77BO",
     "campaign_orchestrator": "CDTGPLYOTCHU2UDFEVVDXUCYSF6VVUVT364DMZV7T4WGOTDZ74GF6FQB",

--- a/frontend/src/components/auction/BidForm.test.tsx
+++ b/frontend/src/components/auction/BidForm.test.tsx
@@ -36,7 +36,7 @@ describe('BidForm', () => {
 
     it('should render floor price correctly', () => {
         render(<BidForm auction={mockAuction} />);
-        expect(screen.getByText('1 XLM')).toBeDefined();
+        expect(screen.getByText('1 XLM')).toBeInTheDocument();
     });
 
     it('should show error if bid is below floor price', async () => {

--- a/frontend/src/components/governance/ProposalCard.test.tsx
+++ b/frontend/src/components/governance/ProposalCard.test.tsx
@@ -20,10 +20,10 @@ describe('ProposalCard', () => {
     it('should render proposal details correctly', () => {
         render(<ProposalCard proposal={mockProposal} />);
 
-        expect(screen.getByText('PIP-1')).toBeDefined();
-        expect(screen.getByText('Upgrade Protocol')).toBeDefined();
-        expect(screen.getByText('Active')).toBeDefined();
-        expect(screen.getByText(/62.5% For/i)).toBeDefined(); // 1000 / (1000+500+100) = 0.625
+        expect(screen.getByText('PIP-1')).toBeInTheDocument();
+        expect(screen.getByText('Upgrade Protocol')).toBeInTheDocument();
+        expect(screen.getByText('Active')).toBeInTheDocument();
+        expect(screen.getByText(/62.5% For/i)).toBeInTheDocument(); // 1000 / (1000+500+100) = 0.625
     });
 
     it('should call onVote when a vote button is clicked', () => {
@@ -39,8 +39,8 @@ describe('ProposalCard', () => {
     it('should show user vote if already voted', () => {
         render(<ProposalCard proposal={mockProposal} userVote="against" />);
 
-        expect(screen.getByText(/You voted:/i)).toBeDefined();
-        expect(screen.getByText('against')).toBeDefined();
+        expect(screen.getByText(/You voted:/i)).toBeInTheDocument();
+        expect(screen.getByText('against')).toBeInTheDocument();
         expect(screen.queryByText('For')).toBeNull(); // Buttons should be hidden
     });
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -76,12 +76,36 @@ else
   echo "[Info] Dry run mode - skipping identity check/funding"
 fi
 
-# Stabilized deployment file
-DEPLOY_FILE="$OUTPUT_DIR/deployed-$NETWORK.json"
+# Stabilized deployment file (avoid writing records during dry-run)
 mkdir -p "$OUTPUT_DIR"
-
-if [ ! -f "$DEPLOY_FILE" ]; then
+if [ "$DRY_RUN" = true ]; then
+  DEPLOY_FILE="$(mktemp -t "pulsartrack-deployed-$NETWORK.XXXXXX.json")"
   echo '{"network": "'"$NETWORK"'", "deployer": "'"$DEPLOYER_ADDRESS"'", "contracts": {}}' > "$DEPLOY_FILE"
+  echo "[Info] Dry run mode - not writing deployment record to $OUTPUT_DIR"
+else
+  DEPLOY_FILE="$OUTPUT_DIR/deployed-$NETWORK.json"
+  if [ ! -f "$DEPLOY_FILE" ]; then
+    echo '{"network": "'"$NETWORK"'", "deployer": "'"$DEPLOYER_ADDRESS"'", "contracts": {}}' > "$DEPLOY_FILE"
+  fi
+
+  # Ensure we never persist the dry-run placeholder as a deployer address
+  python3 -c '
+import json
+import sys
+
+deploy_file, deployer = sys.argv[1], sys.argv[2]
+with open(deploy_file, encoding="utf-8") as f:
+    data = json.load(f)
+
+if data.get("deployer") == "DRY_RUN_ADDRESS":
+    raise SystemExit("Deployment file has DRY_RUN_ADDRESS as deployer; aborting. Update the record or re-deploy without --dry-run.")
+
+if not data.get("deployer"):
+    data["deployer"] = deployer
+    with open(deploy_file, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+' "$DEPLOY_FILE" "$DEPLOYER_ADDRESS"
 fi
 
 # Build all contracts (unless already built or dry run)
@@ -209,8 +233,12 @@ deploy_contract "dispute_resolution"    "pulsar_dispute_resolution"
 deploy_contract "budget_optimizer"      "pulsar_budget_optimizer"
 deploy_contract "anomaly_detector"      "pulsar_anomaly_detector"
 
-echo ""
-echo "=============================================="
-echo "  Deployment complete!"
-echo "  Results saved to: $DEPLOY_FILE"
-echo "=============================================="
+	echo ""
+	echo "=============================================="
+	echo "  Deployment complete!"
+	if [ "$DRY_RUN" = true ]; then
+	  echo "  Dry run complete (no deployment record written)"
+	else
+	  echo "  Results saved to: $DEPLOY_FILE"
+	fi
+	echo "=============================================="


### PR DESCRIPTION
Closes #360
Closes #362
Closes #363
Closes #364

- Wire `rateLimitWrite()` into write endpoints
- Make DOM assertions meaningful in frontend tests
- Align escrow-vault event docs with emitted symbol_short event name
- Prevent `--dry-run` from writing deployment records and guard against DRY_RUN_ADDRESS in deployment files