### PR TITLE
Fix advertiser campaign typing, CI checks, and frontend Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: backend
+      - name: Type check backend
+        run: npm run typecheck
+        working-directory: backend
       - name: Build backend
         run: npm run build
         working-directory: backend
@@ -53,6 +56,12 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         run: npm ci
+        working-directory: frontend
+      - name: Type check frontend
+        run: npm run typecheck
+        working-directory: frontend
+      - name: Lint frontend
+        run: npm run lint
         working-directory: frontend
       - name: Build frontend
         run: npm run build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json package-lock.json* ./
-RUN npm ci --only=production
+RUN npm ci
 
 # Stage 2: Builder
 FROM node:20-alpine AS builder
@@ -13,10 +13,6 @@ WORKDIR /app
 
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
-COPY package.json package-lock.json* ./
-
-# Install all dependencies (including devDependencies for build)
-RUN npm ci
 
 # Copy source code
 COPY . .

--- a/frontend/src/app/advertiser/page.tsx
+++ b/frontend/src/app/advertiser/page.tsx
@@ -4,7 +4,13 @@ import { useState } from 'react';
 import { PlusCircle, BarChart3, Settings, DollarSign, TrendingUp, Eye, MousePointer } from 'lucide-react';
 import { useWalletStore } from '@/store/wallet-store';
 import { WalletConnectButton } from '@/components/wallet/WalletModal';
-import { useCreateCampaign, useCampaignCount, useAdvertiserCampaigns, useAdvertiserStats } from '@/hooks/useContract';
+import {
+  useCreateCampaign,
+  useCampaignCount,
+  useAdvertiserCampaigns,
+  useAdvertiserStats,
+  AdvertiserCampaign,
+} from '@/hooks/useContract';
 import { formatXlm, formatNumber } from '@/lib/display-utils';
 
 interface CampaignForm {
@@ -202,7 +208,7 @@ export default function AdvertiserPage() {
                 </div>
               ) : campaigns && campaigns.length > 0 ? (
                 <div className="space-y-4">
-                  {campaigns.map((camp: any) => (
+                  {campaigns.map((camp: AdvertiserCampaign) => (
                     <div
                       key={camp.id}
                       className="p-4 border border-gray-200 rounded-lg flex justify-between items-center"
@@ -211,14 +217,26 @@ export default function AdvertiserPage() {
                         <h3 className="font-semibold">Campaign #{camp.id}</h3>
                         <p className="text-sm text-gray-500">
                           Status:{" "}
-                          {Object.keys(camp.status || {})[0] || "Unknown"}
+                          {typeof camp.status === "string"
+                            ? camp.status
+                            : Object.keys(camp.status || {})[0] || "Unknown"}
                         </p>
                       </div>
                       <div className="text-right">
-                        <p className="font-medium">{formatXlm(camp.budget)}</p>
+                        <p className="font-medium">
+                          {camp.budget !== undefined
+                            ? formatXlm(camp.budget)
+                            : "—"}
+                        </p>
                         <p className="text-xs text-gray-500">
-                          {camp.current_views?.toString() || 0} /{" "}
-                          {camp.target_views?.toString() || 0} Views
+                          {camp.current_views !== undefined
+                            ? formatNumber(camp.current_views)
+                            : 0}{" "}
+                          /{" "}
+                          {camp.target_views !== undefined
+                            ? formatNumber(camp.target_views)
+                            : 0}{" "}
+                          Views
                         </p>
                       </div>
                     </div>

--- a/frontend/src/hooks/useContract.ts
+++ b/frontend/src/hooks/useContract.ts
@@ -111,6 +111,32 @@ export function useCampaignCount(enabled = true) {
   );
 }
 
+export interface AdvertiserCampaign {
+  id: number;
+  advertiser?: string;
+  budget?: bigint | number;
+  target_views?: bigint | number;
+  current_views?: bigint | number;
+  status?: Record<string, unknown> | string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function toBigintOrNumber(value: unknown): bigint | number | undefined {
+  if (typeof value === "bigint" || typeof value === "number") return value;
+  return undefined;
+}
+
+function normalizeStatus(
+  value: unknown,
+): Record<string, unknown> | string | undefined {
+  if (typeof value === "string") return value;
+  if (isRecord(value)) return value;
+  return undefined;
+}
+
 /**
  * Hook to get all campaigns for an advertiser
  */
@@ -119,11 +145,11 @@ export function useAdvertiserCampaigns(
   campaignCount: number | undefined,
   enabled = true,
 ) {
-  return useQuery({
+  return useQuery<AdvertiserCampaign[]>({
     queryKey: ["advertiser_campaigns", advertiserAddress, campaignCount],
     queryFn: async () => {
       if (!campaignCount) return [];
-      const campaigns: any[] = [];
+      const campaigns: AdvertiserCampaign[] = [];
       // Fetch concurrently for better performance
       const promises = [];
       for (let i = 1; i <= campaignCount; i++) {
@@ -134,9 +160,22 @@ export function useAdvertiserCampaigns(
             args: [u64ToScVal(i)],
           })
             .then((campaign) => {
-              if (campaign && campaign.advertiser === advertiserAddress) {
-                campaigns.push({ id: i, ...campaign });
-              }
+              if (!isRecord(campaign)) return;
+
+              const advertiser =
+                typeof campaign.advertiser === "string"
+                  ? campaign.advertiser
+                  : undefined;
+              if (!advertiser || advertiser !== advertiserAddress) return;
+
+              campaigns.push({
+                id: i,
+                advertiser,
+                budget: toBigintOrNumber(campaign.budget),
+                target_views: toBigintOrNumber(campaign.target_views),
+                current_views: toBigintOrNumber(campaign.current_views),
+                status: normalizeStatus(campaign.status),
+              });
             })
             .catch((err) => {
               console.error(`Failed to fetch campaign ${i}:`, err);

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -124,7 +124,7 @@ deploy_contract() {
   # Check if already deployed
   local EXISTING_ID
   EXISTING_ID=$(
-    python3 -c '
+    python3 - "$DEPLOY_FILE" "$NAME" <<'PY' 2>/dev/null || echo ""
 import json
 import sys
 
@@ -132,7 +132,7 @@ deploy_file, name = sys.argv[1], sys.argv[2]
 with open(deploy_file, encoding="utf-8") as f:
     data = json.load(f)
 print(data["contracts"].get(name, ""))
-' "$DEPLOY_FILE" "$NAME" 2>/dev/null || echo ""
+PY
   )
 
   if [ -n "$EXISTING_ID" ] && [ "$FORCE" = false ]; then
@@ -164,7 +164,7 @@ print(data["contracts"].get(name, ""))
   echo "  -> $CONTRACT_ID"
 
   # Update deploy file
-  python3 -c '
+  python3 - "$NAME" "$CONTRACT_ID" "$DEPLOY_FILE" <<'PY'
 import json
 import sys
 
@@ -175,7 +175,7 @@ data["contracts"][name] = contract_id
 with open(deploy_file, "w", encoding="utf-8") as f:
     json.dump(data, f, indent=2)
     f.write("\n")
-' "$NAME" "$CONTRACT_ID" "$DEPLOY_FILE"
+PY
 }
 
 # Core contracts

--- a/scripts/initialize.sh
+++ b/scripts/initialize.sh
@@ -92,7 +92,7 @@ call_contract() {
 }
 
 read_contract() {
-  python3 -c '
+  python3 - "$DEPLOY_FILE" "$1" <<'PY' 2>/dev/null
 import json
 import sys
 
@@ -100,7 +100,7 @@ deploy_file, name = sys.argv[1], sys.argv[2]
 with open(deploy_file, encoding="utf-8") as f:
     data = json.load(f)
 print(data["contracts"].get(name, ""))
-' "$DEPLOY_FILE" "$1" 2>/dev/null
+PY
 }
 
 echo ""


### PR DESCRIPTION
Summary:
- Remove `any` usage for advertiser campaigns and add safer rendering/empty state
- Fix frontend Dockerfile dependency stages for reliable builds
- Enforce frontend lint + frontend/backend typecheck in CI
- Harden deploy/initialize scripts against injection patterns

Closes #372
Closes #366
Closes #367
Closes #365
