### PR TITLE
fix: SSR hydration, bigint type safety, reputation tiers, resilient stats (#368 #369 #370 #371)

### DIFF
--- a/backend/src/db/repositories/campaigns.ts
+++ b/backend/src/db/repositories/campaigns.ts
@@ -14,7 +14,10 @@ export async function findByCampaignId(campaignId: bigint) {
 }
 
 export async function getStats() {
-  const [total, active, agg] = await Promise.all([
+  // Issue #371 — use Promise.allSettled so a single failing query (e.g. a
+  // transient connection error or table lock on the expensive aggregate) does
+  // not discard results from the queries that succeeded.
+  const [totalResult, activeResult, aggResult] = await Promise.allSettled([
     prisma.campaign.count(),
     prisma.campaign.count({ where: { status: 'Active' } }),
     prisma.campaign.aggregate({
@@ -23,11 +26,31 @@ export async function getStats() {
   ]);
 
   return {
-    totalCampaigns: total,
-    activeCampaigns: active,
-    totalImpressions: Number(agg._sum.impressions ?? 0),
-    totalClicks: Number(agg._sum.clicks ?? 0),
-    totalSpentStroops: Number(agg._sum.spentStroops ?? 0),
+    totalCampaigns:
+      totalResult.status === 'fulfilled' ? totalResult.value : null,
+    activeCampaigns:
+      activeResult.status === 'fulfilled' ? activeResult.value : null,
+    totalImpressions:
+      aggResult.status === 'fulfilled'
+        ? Number(aggResult.value._sum.impressions ?? 0)
+        : null,
+    totalClicks:
+      aggResult.status === 'fulfilled'
+        ? Number(aggResult.value._sum.clicks ?? 0)
+        : null,
+    totalSpentStroops:
+      aggResult.status === 'fulfilled'
+        ? Number(aggResult.value._sum.spentStroops ?? 0)
+        : null,
+    // Expose which sub-queries failed so callers can show partial-data notices.
+    _partial:
+      [totalResult, activeResult, aggResult].some((r) => r.status === 'rejected')
+        ? {
+            total: totalResult.status === 'rejected',
+            active: activeResult.status === 'rejected',
+            aggregate: aggResult.status === 'rejected',
+          }
+        : undefined,
   };
 }
 

--- a/backend/src/routes/campaigns.test.ts
+++ b/backend/src/routes/campaigns.test.ts
@@ -9,23 +9,72 @@ describe('Campaign Routes', () => {
     const token = generateTestToken(mockAddress);
 
     describe('GET /api/campaigns/stats', () => {
-        it('should return campaign statistics', async () => {
+        // Issue #369 — mock uses string values matching PostgreSQL bigint columns,
+        // and assertions verify both the numeric type and value after conversion.
+        it('should return campaign statistics with correct numeric conversions', async () => {
             (pool.query as any).mockResolvedValue({
                 rows: [{
-                    total_campaigns: 10,
-                    active_campaigns: 5,
+                    total_campaigns: '10',       // PostgreSQL returns bigint as string
+                    active_campaigns: '5',
                     total_impressions: '1000',
                     total_clicks: '50',
-                    total_spent_stroops: '100000000'
+                    total_spent_stroops: '100000000', // 100 000 000 stroops = 10 XLM
                 }]
             });
 
             const response = await request(app).get('/api/campaigns/stats');
 
             expect(response.status).toBe(200);
+
+            // Verify field presence
             expect(response.body).toHaveProperty('total_campaigns');
             expect(response.body).toHaveProperty('active_campaigns');
-            expect(response.body.total_spent_xlm).toBe(10);
+            expect(response.body).toHaveProperty('total_spent_xlm');
+
+            // Issue #369 — explicitly assert numeric type so implicit JS coercion
+            // of a string doesn't mask a missing conversion in the route handler.
+            expect(typeof response.body.total_spent_xlm).toBe('number');
+            expect(response.body.total_spent_xlm).toBeCloseTo(10, 5);
+
+            // Verify zero-stroops edge case doesn't produce NaN or null
+            expect(Number.isFinite(response.body.total_spent_xlm)).toBe(true);
+        });
+
+        it('should convert zero stroops to 0 XLM', async () => {
+            (pool.query as any).mockResolvedValue({
+                rows: [{
+                    total_campaigns: '0',
+                    active_campaigns: '0',
+                    total_impressions: '0',
+                    total_clicks: '0',
+                    total_spent_stroops: '0',
+                }]
+            });
+
+            const response = await request(app).get('/api/campaigns/stats');
+
+            expect(response.status).toBe(200);
+            expect(typeof response.body.total_spent_xlm).toBe('number');
+            expect(response.body.total_spent_xlm).toBe(0);
+        });
+
+        it('should handle large stroops values without precision loss', async () => {
+            // 1 billion XLM in stroops — tests large integer handling
+            (pool.query as any).mockResolvedValue({
+                rows: [{
+                    total_campaigns: '1',
+                    active_campaigns: '1',
+                    total_impressions: '999999',
+                    total_clicks: '12345',
+                    total_spent_stroops: '10000000000000000', // 1 000 000 000 XLM
+                }]
+            });
+
+            const response = await request(app).get('/api/campaigns/stats');
+
+            expect(response.status).toBe(200);
+            expect(typeof response.body.total_spent_xlm).toBe('number');
+            expect(Number.isFinite(response.body.total_spent_xlm)).toBe(true);
         });
     });
 

--- a/frontend/src/app/publisher/page.tsx
+++ b/frontend/src/app/publisher/page.tsx
@@ -295,28 +295,35 @@ export default function PublisherPage() {
                   Publisher Tiers
                 </h3>
                 <div className="space-y-2">
-                  {[
-                    { tier: 'Bronze', min: 0, max: 399, color: 'amber' },
-                    { tier: 'Silver', min: 400, max: 599, color: 'gray' },
-                    { tier: 'Gold', min: 600, max: 799, color: 'yellow' },
-                    { tier: 'Platinum', min: 800, max: 1000, color: 'blue' },
-                  ].map(({ tier, min, max, color }) => (
-                    <div
-                      key={tier}
-                      className={`flex items-center justify-between px-3 py-2 rounded-lg ${
-                        reputationScore >= min && reputationScore <= max
-                          ? 'bg-indigo-50 border border-indigo-200'
-                          : 'bg-gray-50'
-                      }`}
-                    >
-                      <span className="text-sm font-medium text-gray-900">
-                        {tier}
-                      </span>
-                      <span className="text-xs text-gray-500">
-                        {min} - {max} score
-                      </span>
-                    </div>
-                  ))}
+                  {/* Issue #370 — Platinum uses Infinity as upper bound so scores
+                      above 1000 still resolve to a tier. Negative scores are clamped
+                      to 0 before matching so they always land in Bronze. */}
+                  {([
+                    { tier: 'Bronze',   min: 0,   max: 399,      color: 'amber'  },
+                    { tier: 'Silver',   min: 400,  max: 599,      color: 'gray'   },
+                    { tier: 'Gold',     min: 600,  max: 799,      color: 'yellow' },
+                    { tier: 'Platinum', min: 800,  max: Infinity, color: 'blue'   },
+                  ] as Array<{ tier: string; min: number; max: number; color: string }>).map(({ tier, min, max }) => {
+                    const score = Math.max(reputationScore, 0);
+                    const isActive = score >= min && score <= max;
+                    const rangeLabel =
+                      max === Infinity ? `${min}+ score` : `${min} – ${max} score`;
+                    return (
+                      <div
+                        key={tier}
+                        className={`flex items-center justify-between px-3 py-2 rounded-lg ${
+                          isActive
+                            ? 'bg-indigo-50 border border-indigo-200'
+                            : 'bg-gray-50'
+                        }`}
+                      >
+                        <span className="text-sm font-medium text-gray-900">
+                          {tier}
+                        </span>
+                        <span className="text-xs text-gray-500">{rangeLabel}</span>
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
             </div>

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+// Issue #368 — _hydrated replaces the local `mounted` pattern
 import { Menu, X, Zap, History, AlertTriangle, Moon, Sun, Monitor } from "lucide-react";
 import { useWalletStore } from "../store/wallet-store";
 import { useTransactionStore } from "../store/tx-store";
@@ -13,9 +14,8 @@ import { useTxNotifications } from "../hooks/useTxNotifications";
 import { useThemeStore, ThemeMode } from "../store/theme-store";
 
 export function Header() {
-  const { address, isConnected, networkMismatch } = useWalletStore();
+  const { address, isConnected, networkMismatch, _hydrated } = useWalletStore();
   const { getPendingTransactions } = useTransactionStore();
-  const [mounted, setMounted] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [txHistoryOpen, setTxHistoryOpen] = useState(false);
   const [pendingCount, setPendingCount] = useState(0);
@@ -33,8 +33,6 @@ export function Header() {
   useTxNotifications();
 
   useEffect(() => {
-    setMounted(true);
-
     const check = async () => {
       try {
         await checkPendingTransactions();
@@ -43,23 +41,18 @@ export function Header() {
       }
     };
 
-    // Check pending transactions on mount
     check();
-
-    // Set up interval to check pending transactions periodically
-    const interval = setInterval(check, 30000); // Check every 30 seconds
-
+    const interval = setInterval(check, 30000);
     return () => clearInterval(interval);
   }, []);
 
   useEffect(() => {
-    // Update pending count
-    if (mounted) {
+    if (_hydrated) {
       setPendingCount(getPendingTransactions().length);
     }
-  }, [mounted, getPendingTransactions]);
+  }, [_hydrated, getPendingTransactions]);
 
-  if (!mounted) return null;
+  if (!_hydrated) return null;
 
   return (
     <>

--- a/frontend/src/store/tx-store.ts
+++ b/frontend/src/store/tx-store.ts
@@ -27,17 +27,22 @@ export interface Transaction {
 
 interface TransactionStore {
   transactions: Transaction[];
+  /** Issue #368 — true once Zustand has rehydrated from localStorage. */
+  _hydrated: boolean;
   addTransaction: (tx: Omit<Transaction, "timestamp">) => void;
   updateTransaction: (txHash: string, updates: Partial<Transaction>) => void;
   getTransaction: (txHash: string) => Transaction | undefined;
   getPendingTransactions: () => Transaction[];
   clearOldTransactions: (olderThanDays?: number) => void;
+  setHydrated: (value: boolean) => void;
 }
 
 export const useTransactionStore = create<TransactionStore>()(
   persist(
     (set, get) => ({
       transactions: [],
+      _hydrated: false,
+      setHydrated: (value) => set({ _hydrated: value }),
 
       addTransaction: (tx) =>
         set((state) => ({
@@ -85,6 +90,10 @@ export const useTransactionStore = create<TransactionStore>()(
               removeItem: () => {},
             } as any),
       ),
+      // Issue #368 — signal rehydration completion to eliminate header flicker.
+      onRehydrateStorage: () => (state) => {
+        state?.setHydrated(true);
+      },
     },
   ),
 );

--- a/frontend/src/store/wallet-store.ts
+++ b/frontend/src/store/wallet-store.ts
@@ -10,6 +10,8 @@ interface WalletStore {
   network: string;
   freighterNetwork: string | null;
   networkMismatch: boolean;
+  /** Issue #368 — true once Zustand has rehydrated from localStorage. */
+  _hydrated: boolean;
   setAddress: (address: string | null) => void;
   setConnected: (connected: boolean) => void;
   setNetwork: (network: string) => void;
@@ -17,6 +19,7 @@ interface WalletStore {
   setNetworkMismatch: (mismatch: boolean) => void;
   disconnect: () => void;
   autoReconnect: () => Promise<void>;
+  setHydrated: (value: boolean) => void;
 }
 
 export const useWalletStore = create<WalletStore>()(
@@ -27,11 +30,13 @@ export const useWalletStore = create<WalletStore>()(
       network: "testnet",
       freighterNetwork: null,
       networkMismatch: false,
+      _hydrated: false,
       setAddress: (address) => set({ address }),
       setConnected: (connected) => set({ isConnected: connected }),
       setNetwork: (network) => set({ network }),
       setFreighterNetwork: (freighterNetwork) => set({ freighterNetwork }),
       setNetworkMismatch: (networkMismatch) => set({ networkMismatch }),
+      setHydrated: (value) => set({ _hydrated: value }),
       disconnect: () =>
         set({ address: null, isConnected: false, networkMismatch: false, freighterNetwork: null }),
       // Auto-reconnect flow callable by client code (checks connection and network)
@@ -70,6 +75,12 @@ export const useWalletStore = create<WalletStore>()(
               removeItem: () => {},
             } as any),
       ),
+      // Issue #368 — set _hydrated=true once Zustand has read localStorage.
+      // Components can gate rendering on this flag instead of using a local
+      // `mounted` useState, which eliminates the header flicker.
+      onRehydrateStorage: () => (state) => {
+        state?.setHydrated(true);
+      },
     },
   ),
 );


### PR DESCRIPTION
Fixes #368
Fixes #369
Fixes #370
Fixes #371

## What changed

- **#368 — SSR hydration**: Replaced the local `mounted` useState guard in `Header` with the store-level `_hydrated` flag. Both `wallet-store` and `tx-store` now set `_hydrated: true` via `onRehydrateStorage` in the Zustand persist config, so the component waits for localStorage rehydration before rendering — eliminating the flash of wrong content.

- **#369 — Bigint type safety**: Campaign test mocks now use string values for Prisma bigint columns (matching real DB output). Added `expect(typeof response.body.total_spent_xlm).toBe('number')` assertions to verify the API converts bigints to JS numbers correctly, plus edge-case tests for zero and large stoop values.

- **#370 — Reputation tier boundaries**: Changed the Platinum tier `max` from `1000` to `Infinity` so scores above 1000 still resolve to a valid tier. Added `Math.max(reputationScore, 0)` clamping so negative scores fall to Bronze. The range label dynamically shows `"800+ score"` for open-ended tiers.

- **#371 — Resilient campaign stats**: Replaced `Promise.all` with `Promise.allSettled` in `getStats()`. Individual DB query failures now return `null` fields instead of rejecting the entire request. A `_partial` object is included in the response when any sub-query fails, so callers can detect degraded data.

## How to test

- **#368**: Connect wallet, refresh — no flash of disconnected state before store rehydrates.
- **#369**: `cd backend && npx vitest run src/routes/campaigns.test.ts` — all type assertions pass.
- **#370**: Set reputation score to 1050 — badge shows Platinum. Set to -10 — badge shows Bronze.
- **#371**: Mock one Prisma call to reject — endpoint still returns 200 with `_partial` populated.