### PR TITLE
fix: resolve security issues #396, #397, #398, #399

### DIFF
--- a/contracts/performance-oracle/src/lib.rs
+++ b/contracts/performance-oracle/src/lib.rs
@@ -49,6 +49,7 @@ const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
 const INSTANCE_BUMP_AMOUNT: u32 = 86_400;
 const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
 const PERSISTENT_BUMP_AMOUNT: u32 = 1_051_200;
+const MAX_CONSENSUS_ATTESTERS: u32 = 50;
 
 #[contract]
 pub struct PerformanceOracleContract;
@@ -121,6 +122,17 @@ impl PerformanceOracleContract {
             .has(&DataKey::Attestation(campaign_id, attester.clone()))
         {
             panic!("already attested");
+        }
+
+        // Enforce hard cap on attesters to prevent exceeding Soroban CPU limits
+        let count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AttestationCount(campaign_id))
+            .unwrap_or(0);
+
+        if count >= MAX_CONSENSUS_ATTESTERS {
+            panic!("attester limit reached");
         }
 
         let attestation = PerformanceAttestation {

--- a/contracts/publisher-verification/src/lib.rs
+++ b/contracts/publisher-verification/src/lib.rs
@@ -207,7 +207,6 @@ impl PublisherVerificationContract {
         env: Env,
         admin: Address,
         publisher: Address,
-        initial_tier: PublisherTier,
     ) {
         env.storage()
             .instance()
@@ -225,9 +224,10 @@ impl PublisherVerificationContract {
             .expect("publisher not found");
 
         pub_data.status = VerificationStatus::Verified;
-        pub_data.tier = initial_tier;
         pub_data.verified_at = Some(env.ledger().timestamp());
         pub_data.reputation_score = 100;
+        // Derive tier from starting score to prevent admin from assigning unearned tiers
+        pub_data.tier = Self::_score_to_tier(100);
 
         let _ttl_key = DataKey::Publisher(publisher.clone());
         env.storage().persistent().set(&_ttl_key, &pub_data);

--- a/contracts/publisher-verification/src/test.rs
+++ b/contracts/publisher-verification/src/test.rs
@@ -113,11 +113,13 @@ fn test_verify_publisher() {
     let pub1 = Address::generate(&env);
     c.register_publisher(&pub1, &s(&env, "example.com"));
     c.submit_kyc(&pub1, &s(&env, "KycHash"), &s(&env, "KycProvider"));
-    c.verify_publisher(&admin, &pub1, &PublisherTier::Gold);
+    c.verify_publisher(&admin, &pub1);
     let p = c.get_publisher(&pub1).unwrap();
     assert!(matches!(p.status, VerificationStatus::Verified));
     assert!(p.verified_at.is_some());
     assert_eq!(p.reputation_score, 100);
+    // Tier should be Bronze for score of 100
+    assert!(matches!(p.tier, PublisherTier::Bronze));
     assert!(c.is_verified(&pub1));
     let kyc = c.get_kyc(&pub1).unwrap();
     assert!(kyc.verified);
@@ -131,7 +133,7 @@ fn test_verify_publisher_unauthorized() {
     let (c, _) = setup(&env);
     let pub1 = Address::generate(&env);
     c.register_publisher(&pub1, &s(&env, "example.com"));
-    c.verify_publisher(&Address::generate(&env), &pub1, &PublisherTier::Bronze);
+    c.verify_publisher(&Address::generate(&env), &pub1);
 }
 
 #[test]
@@ -142,7 +144,7 @@ fn test_suspend_publisher() {
     let pub1 = Address::generate(&env);
     c.register_publisher(&pub1, &s(&env, "example.com"));
     c.submit_kyc(&pub1, &s(&env, "KycHash"), &s(&env, "KycProvider"));
-    c.verify_publisher(&admin, &pub1, &PublisherTier::Silver);
+    c.verify_publisher(&admin, &pub1);
     c.suspend_publisher(&admin, &pub1);
     assert!(!c.is_verified(&pub1));
 }
@@ -179,7 +181,7 @@ fn test_record_impression() {
     let caller = Address::generate(&env);
     c.register_publisher(&pub1, &s(&env, "example.com"));
     c.submit_kyc(&pub1, &s(&env, "KycHash"), &s(&env, "KycProvider"));
-    c.verify_publisher(&admin, &pub1, &PublisherTier::Gold);
+    c.verify_publisher(&admin, &pub1);
     c.record_impression(&caller, &pub1, &1000i128);
     let p = c.get_publisher(&pub1).unwrap();
     assert_eq!(p.total_impressions, 1);

--- a/contracts/rewards-distributor/src/lib.rs
+++ b/contracts/rewards-distributor/src/lib.rs
@@ -173,12 +173,12 @@ impl RewardsDistributorContract {
                 total_claimed: 0,
                 pending: 0,
                 last_earned: 0,
-                vesting_start: now,
+                vesting_start: 0,
                 vesting_duration,
             });
 
-        // Initialize vesting_start on first distribution if not set
-        if rewards.total_earned == 0 {
+        // Initialize vesting_start on first distribution using vesting_start == 0 as sentinel
+        if rewards.vesting_start == 0 {
             rewards.vesting_start = now;
             rewards.vesting_duration = vesting_duration;
         }

--- a/contracts/timelock-executor/src/lib.rs
+++ b/contracts/timelock-executor/src/lib.rs
@@ -126,6 +126,10 @@ impl TimelockExecutorContract {
         let now = env.ledger().timestamp();
         let grace: u64 = env.storage().instance().get(&DataKey::GracePeriod).unwrap();
 
+        // Validate that eta + grace_period won't overflow
+        let eta = now.checked_add(delay_secs).expect("eta calculation overflows u64");
+        let _grace_end = eta.checked_add(grace).expect("grace period end overflows u64");
+
         let entry = TimelockEntry {
             entry_id,
             proposer: proposer.clone(),
@@ -133,7 +137,7 @@ impl TimelockExecutorContract {
             function_name,
             args,
             description,
-            eta: now + delay_secs,
+            eta,
             grace_period: grace,
             status: TimelockStatus::Queued,
             queued_at: now,
@@ -190,7 +194,11 @@ impl TimelockExecutorContract {
             panic!("timelock not expired");
         }
 
-        if now > entry.eta + entry.grace_period {
+        // Use checked arithmetic to prevent overflow when computing grace period end
+        let grace_end = entry.eta.checked_add(entry.grace_period)
+            .expect("grace period end overflows u64");
+
+        if now > grace_end {
             entry.status = TimelockStatus::Expired;
             let _ttl_key = DataKey::Entry(entry_id);
             env.storage().persistent().set(&_ttl_key, &entry);
@@ -268,9 +276,14 @@ impl TimelockExecutorContract {
             .get::<DataKey, TimelockEntry>(&DataKey::Entry(entry_id))
         {
             let now = env.ledger().timestamp();
-            entry.status == TimelockStatus::Queued
-                && now >= entry.eta
-                && now <= entry.eta + entry.grace_period
+            // Use checked arithmetic to prevent overflow
+            if let Some(grace_end) = entry.eta.checked_add(entry.grace_period) {
+                entry.status == TimelockStatus::Queued
+                    && now >= entry.eta
+                    && now <= grace_end
+            } else {
+                false
+            }
         } else {
             false
         }


### PR DESCRIPTION
closes #396 
closes #397 
closes #398 
closes #399 

- Remove initial_tier parameter from verify_publisher to prevent admin from assigning unearned tiers. Tier is now derived from starting reputation score of 100.

-  Add MAX_CONSENSUS_ATTESTERS constant (50) to prevent unbounded loop in performance oracle that could exceed Soroban CPU limits.

- Add checked arithmetic for grace period calculations in timelock executor to prevent integer overflow vulnerabilities.

-  Fix vesting bypass by using vesting_start == 0 as sentinel instead of total_earned == 0, ensuring subsequent distributions maintain proper vesting schedules.