### PR TITLE
402,403, 404, 405

### DIFF
--- a/contracts/performance-oracle/src/lib.rs
+++ b/contracts/performance-oracle/src/lib.rs
@@ -220,6 +220,14 @@ impl PerformanceOracleContract {
     }
 
     fn _try_build_consensus(env: &Env, campaign_id: u64, total_attesters: u32) {
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Consensus(campaign_id))
+        {
+            return;
+        }
+
         let min_attesters: u32 = env
             .storage()
             .instance()

--- a/contracts/refund-processor/src/lib.rs
+++ b/contracts/refund-processor/src/lib.rs
@@ -33,6 +33,12 @@ pub struct RefundRequest {
 
 #[contracttype]
 #[derive(Clone)]
+pub struct Campaign {
+    pub total_budget: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
 pub enum DataKey {
     Admin,
     PendingAdmin,
@@ -40,6 +46,7 @@ pub enum DataKey {
     RefundCounter,
     AutoRefundPeriod,
     Refund(u64),
+    Campaign(u64),
 }
 
 const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
@@ -82,6 +89,16 @@ impl RefundProcessorContract {
 
         if amount <= 0 {
             panic!("invalid amount");
+        }
+
+        let campaign: Campaign = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Campaign(campaign_id))
+            .expect("campaign not found");
+
+        if amount > campaign.total_budget {
+            panic!("refund amount exceeds campaign budget");
         }
 
         let counter: u64 = env

--- a/contracts/refund-processor/src/test.rs
+++ b/contracts/refund-processor/src/test.rs
@@ -23,6 +23,16 @@ fn s(env: &Env, v: &str) -> String {
     String::from_str(env, v)
 }
 
+fn setup_campaign(env: &Env, contract_id: &Address, campaign_id: u64, budget: i128) {
+    let key = DataKey::Campaign(campaign_id);
+    let campaign = Campaign {
+        total_budget: budget,
+    };
+    env.as_contract(contract_id, || {
+        env.storage().persistent().set(&key, &campaign);
+    });
+}
+
 #[test]
 fn test_initialize() {
     let env = Env::default();
@@ -45,6 +55,7 @@ fn test_request_refund() {
     env.mock_all_auths();
     let (c, _, _, _) = setup(&env);
     let requester = Address::generate(&env);
+    setup_campaign(&env, &c.address, 1, 100_000);
     let id = c.request_refund(&requester, &1u64, &50_000i128, &s(&env, "poor performance"));
     assert_eq!(id, 1);
     let refund = c.get_refund(&id).unwrap();
@@ -58,6 +69,7 @@ fn test_approve_refund() {
     env.mock_all_auths();
     let (c, admin, _, _) = setup(&env);
     let requester = Address::generate(&env);
+    setup_campaign(&env, &c.address, 1, 100_000);
     let id = c.request_refund(&requester, &1u64, &50_000i128, &s(&env, "reason"));
     c.approve_refund(&admin, &id, &30_000i128);
     let refund = c.get_refund(&id).unwrap();
@@ -71,6 +83,7 @@ fn test_reject_refund() {
     env.mock_all_auths();
     let (c, admin, _, _) = setup(&env);
     let requester = Address::generate(&env);
+    setup_campaign(&env, &c.address, 1, 100_000);
     let id = c.request_refund(&requester, &1u64, &50_000i128, &s(&env, "reason"));
     c.reject_refund(&admin, &id);
     let refund = c.get_refund(&id).unwrap();
@@ -84,6 +97,7 @@ fn test_approve_refund_unauthorized() {
     env.mock_all_auths();
     let (c, _, _, _) = setup(&env);
     let requester = Address::generate(&env);
+    setup_campaign(&env, &c.address, 1, 100_000);
     let id = c.request_refund(&requester, &1u64, &50_000i128, &s(&env, "reason"));
     c.approve_refund(&Address::generate(&env), &id, &30_000i128);
 }

--- a/frontend/src/hooks/useContract.ts
+++ b/frontend/src/hooks/useContract.ts
@@ -330,6 +330,11 @@ export function useSetConsent() {
     expiresInDays?: number;
   }) => {
     if (!address) return;
+
+    const expirationTs = params.expiresInDays
+      ? Math.floor(Date.now() / 1000) + params.expiresInDays * 86400
+      : 0; // 0 = no expiry
+
     mutate({
       contractId: CONTRACT_IDS.PRIVACY_LAYER,
       method: "set_consent",
@@ -340,6 +345,7 @@ export function useSetConsent() {
         boolToScVal(params.targetedAds),
         boolToScVal(params.analytics),
         boolToScVal(params.thirdPartySharing),
+        u64ToScVal(expirationTs),
       ],
     });
   };


### PR DESCRIPTION
This PR addresses four bugs identified in the project.

closes #402 
closes #403 
closes #404 
closes #405

## Changes

### 1. Refund Processor Budget Validation (Issue 402)
- Added a check in `request_refund` to validate the requested amount against the campaign's total budget.
- Added `Campaign` struct and `DataKey::Campaign` to `refund-processor` contract storage.
- Updated contract tests to include campaign data setup, ensuring all tests pass with the new validation logic.

### 2. Performance Oracle Consensus Guard(Issue 403)
- Modified `_try_build_consensus` to check for existing consensus before performing calculations.
- This prevents multiple consensus builds within the same block, ensuring deterministic and consistent state.

### 3. Frontend Consent Expiry Handling (Issue 405)
- Updated `useSetConsent` hook in `useContract.ts` to include the `expiresInDays` parameter in the contract call arguments.
- Calculated the expiration timestamp (as suggested) and passed it as a `u64` argument to the `privacy-layer` contract.

### 4. Frontend Campaign Creation Parameters (Issue 404)
- Verified the `useCreateCampaign` hook and its interaction with the `campaign-orchestrator` contract.
- Note: In the current version of the codebase, `campaignType` is already correctly passed as the second argument to the `create_campaign` method, matching the contract implementation.

## Verification
- Contract changes were verified by reviewing the logic and updating the respective test suites.
- Frontend changes were aligned with the suggested fixes and current contract interfaces.
