### PR TITLE
fix: restrict unauthorized conversion recording in analytics aggregator

### DIFF
--- a/contracts/analytics-aggregator/src/lib.rs
+++ b/contracts/analytics-aggregator/src/lib.rs
@@ -200,7 +200,7 @@ impl AnalyticsAggregatorContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
-        caller.require_auth();
+        require_oracle(&env, &caller);
 
         let mut analytics: CampaignAnalytics = env
             .storage()

--- a/contracts/analytics-aggregator/src/test.rs
+++ b/contracts/analytics-aggregator/src/test.rs
@@ -106,11 +106,9 @@ fn test_record_conversion_increments_count() {
     let env = Env::default();
     env.mock_all_auths();
     let (c, _, oracle) = setup(&env);
-    let caller = Address::generate(&env);
-
     c.record_impression(&oracle, &1u64, &100i128);
     c.record_click(&oracle, &1u64);
-    c.record_conversion(&caller, &1u64);
+    c.record_conversion(&oracle, &1u64);
 
     let a = c.get_campaign_analytics(&1u64).unwrap();
     assert_eq!(a.total_conversions, 1);
@@ -121,15 +119,13 @@ fn test_record_conversion_calculates_cvr() {
     let env = Env::default();
     env.mock_all_auths();
     let (c, _, oracle) = setup(&env);
-    let caller = Address::generate(&env);
-
     // 4 impressions, 2 clicks, 1 conversion → cvr = 1/2 * 10000 = 5000
     for _ in 0..4 {
         c.record_impression(&oracle, &1u64, &100i128);
     }
     c.record_click(&oracle, &1u64);
     c.record_click(&oracle, &1u64);
-    c.record_conversion(&caller, &1u64);
+    c.record_conversion(&oracle, &1u64);
 
     let a = c.get_campaign_analytics(&1u64).unwrap();
     assert_eq!(a.cvr, 5000);
@@ -155,8 +151,20 @@ fn test_cvr_stays_zero_without_clicks() {
 fn test_record_conversion_without_analytics_panics() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, _, _) = setup(&env);
+    let (c, _, oracle) = setup(&env);
+
+    c.record_conversion(&oracle, &999u64);
+}
+
+#[test]
+#[should_panic(expected = "only oracle can record analytics")]
+fn test_record_conversion_rejects_non_oracle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _, oracle) = setup(&env);
     let caller = Address::generate(&env);
 
-    c.record_conversion(&caller, &999u64);
+    c.record_impression(&oracle, &1u64, &100i128);
+    c.record_click(&oracle, &1u64);
+    c.record_conversion(&caller, &1u64);
 }

--- a/contracts/analytics-aggregator/test_snapshots/test/test_record_conversion_calculates_cvr.1.json
+++ b/contracts/analytics-aggregator/test_snapshots/test/test_record_conversion_calculates_cvr.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 4,
+    "address": 3,
     "nonce": 0
   },
   "auth": [
@@ -185,7 +185,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -193,7 +193,7 @@
               "function_name": "record_conversion",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
                   "u64": 1
@@ -404,6 +404,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 6277191135259896685
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 6277191135259896685
                   }
                 },
                 "durability": "temporary",
@@ -778,39 +811,6 @@
             "ext": "v0"
           },
           86400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 6277191135259896685
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 6277191135259896685
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
         ]
       ],
       [

--- a/contracts/analytics-aggregator/test_snapshots/test/test_record_conversion_rejects_non_oracle.1.json
+++ b/contracts/analytics-aggregator/test_snapshots/test/test_record_conversion_rejects_non_oracle.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0
   },
   "auth": [
@@ -63,28 +63,6 @@
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
               "function_name": "record_click",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "u64": 1
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "function_name": "record_conversion",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
@@ -166,39 +144,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 1033654523790656264
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 4837995959683129791
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 4837995959683129791
                   }
                 },
                 "durability": "temporary",
@@ -312,7 +257,7 @@
                         "symbol": "cvr"
                       },
                       "val": {
-                        "u32": 10000
+                        "u32": 0
                       }
                     },
                     {
@@ -336,7 +281,7 @@
                         "symbol": "total_conversions"
                       },
                       "val": {
-                        "u64": 1
+                        "u64": 0
                       }
                     },
                     {

--- a/contracts/analytics-aggregator/test_snapshots/test/test_record_conversion_without_analytics_panics.1.json
+++ b/contracts/analytics-aggregator/test_snapshots/test/test_record_conversion_without_analytics_panics.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 4,
+    "address": 3,
     "nonce": 0
   },
   "auth": [


### PR DESCRIPTION
## Summary
- enforce oracle-only authorization in `record_conversion` by reusing `require_oracle`
- update conversion tests to call `record_conversion` with the configured oracle
- add a regression test to ensure non-oracle callers are rejected

## Test plan
- [x] `cargo test` in `contracts/analytics-aggregator`
- [x] verified `record_conversion` panics for non-oracle callers
- [x] verified conversion increment/CVR flows still pass with oracle caller

Closes ThinkLikeAFounder/pulsartrack#433

