### PR TITLE
fix: resolve critical security vulnerabilities in Wrapped Token, Auction Engine, and Governance DAO

### DIFF
--- a/contracts/auction-engine/src/lib.rs
+++ b/contracts/auction-engine/src/lib.rs
@@ -274,7 +274,43 @@ impl AuctionEngineContract {
             panic!("auction still running");
         }
 
-        auction.status = if let Some(winning) = auction.winning_bid {
+        if auction.status == AuctionStatus::Settled || auction.status == AuctionStatus::Cancelled {
+            panic!("auction already settled or cancelled");
+        }
+
+        let winning = auction.winning_bid;
+        let winner = auction.winner.clone();
+
+        // 1. Effects: Update state and storage first
+        auction.status = if let Some(amount) = winning {
+            if amount >= auction.reserve_price {
+                AuctionStatus::Settled
+            } else {
+                AuctionStatus::Cancelled
+            }
+        } else {
+            AuctionStatus::Cancelled
+        };
+
+        // Clear winner and winning bid to prevent double-settlement on retry
+        auction.winner = None;
+        auction.winning_bid = None;
+
+        // Persist the updated state
+        let _ttl_key = DataKey::Auction(auction_id);
+        env.storage().persistent().set(&_ttl_key, &auction);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+        // Remove highest bid key
+        env.storage()
+            .persistent()
+            .remove(&DataKey::HighestBid(auction_id));
+
+        // 2. Interactions: Transfer funds based on finalized status
+        if let Some(amount) = winning {
             let token_addr: Address = env
                 .storage()
                 .instance()
@@ -282,33 +318,14 @@ impl AuctionEngineContract {
                 .unwrap();
             let token_client = token::Client::new(&env, &token_addr);
 
-            if winning >= auction.reserve_price {
-                // Transfer payment from contract to publisher
-                token_client.transfer(
-                    &env.current_contract_address(),
-                    &auction.publisher,
-                    &winning,
-                );
-                AuctionStatus::Settled
-            } else {
-                // Refund the highest bidder because reserve not met
-                if let Some(winner) = &auction.winner {
-                    token_client.transfer(&env.current_contract_address(), winner, &winning);
-                    env.storage()
-                        .persistent()
-                        .remove(&DataKey::BidderBid(auction_id, winner.clone()));
-                }
-                AuctionStatus::Cancelled
-            }
-        } else {
-            AuctionStatus::Cancelled
-        };
-
-        if auction.status == AuctionStatus::Settled {
-            if let Some(winner) = &auction.winner {
+            if auction.status == AuctionStatus::Settled {
+                token_client.transfer(&env.current_contract_address(), &auction.publisher, &amount);
+            } else if let Some(voter_addr) = winner {
+                // Refund because reserve price was not met
+                token_client.transfer(&env.current_contract_address(), &voter_addr, &amount);
                 env.storage()
                     .persistent()
-                    .remove(&DataKey::BidderBid(auction_id, winner.clone()));
+                    .remove(&DataKey::BidderBid(auction_id, voter_addr));
             }
         }
 

--- a/contracts/governance-dao/src/lib.rs
+++ b/contracts/governance-dao/src/lib.rs
@@ -79,6 +79,7 @@ pub enum DataKey {
     Proposal(u64),
     Vote(u64, Address),
     HasVoted(u64, Address),
+    LockedTokens(u64, Address), // proposal_id, voter
 }
 
 // ============================================================
@@ -269,6 +270,18 @@ impl GovernanceDaoContract {
             panic!("invalid voting power");
         }
 
+        // Lock tokens: Transfer from voter to the DAO contract
+        token_client.transfer(&voter, &env.current_contract_address(), &power);
+
+        // Record locked tokens
+        let _ttl_key = DataKey::LockedTokens(proposal_id, voter.clone());
+        env.storage().persistent().set(&_ttl_key, &power);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
         // Record vote
         match choice {
             VoteChoice::For => proposal.votes_for += power,
@@ -410,6 +423,50 @@ impl GovernanceDaoContract {
         // Any execution side effects (e.g. calling proposal.target_contract)
         // must be placed here — after the status has been committed — so they
         // cannot be replayed if they succeed but the status write were to fail.
+    }
+
+    /// Unlock tokens after proposal is finalized
+    pub fn unlock_tokens(env: Env, voter: Address, proposal_id: u64) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        voter.require_auth();
+
+        let proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("proposal not found");
+
+        // Can only unlock if the proposal is no longer Active
+        if proposal.status == ProposalStatus::Active
+            && env.ledger().sequence() <= proposal.end_ledger
+        {
+            panic!("proposal still active");
+        }
+
+        let key = DataKey::LockedTokens(proposal_id, voter.clone());
+        let amount: i128 = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("no tokens locked for this proposal");
+
+        // Remove record before transfer (CEI)
+        env.storage().persistent().remove(&key);
+
+        let gov_token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::GovernanceToken)
+            .unwrap();
+        let token_client = token::Client::new(&env, &gov_token);
+        token_client.transfer(&env.current_contract_address(), &voter, &amount);
+
+        env.events().publish(
+            (symbol_short!("gov"), symbol_short!("unlocked")),
+            (proposal_id, voter, amount),
+        );
     }
 
     /// Cancel a proposal (proposer or admin)

--- a/contracts/wrapped-token/src/lib.rs
+++ b/contracts/wrapped-token/src/lib.rs
@@ -146,6 +146,10 @@ impl WrappedTokenContract {
             panic!("source transaction already processed");
         }
 
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
         let mut wrapped: WrappedToken = env
             .storage()
             .persistent()
@@ -161,14 +165,18 @@ impl WrappedTokenContract {
         // For now, we track the internal balance
         let key = DataKey::UserBalance(symbol.clone(), recipient.clone());
         let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
-        env.storage().persistent().set(&key, &(current + amount));
+        let new_balance = current.checked_add(amount).expect("balance overflow");
+        env.storage().persistent().set(&key, &new_balance);
         env.storage().persistent().extend_ttl(
             &key,
             PERSISTENT_LIFETIME_THRESHOLD,
             PERSISTENT_BUMP_AMOUNT,
         );
 
-        wrapped.total_wrapped += amount;
+        wrapped.total_wrapped = wrapped
+            .total_wrapped
+            .checked_add(amount)
+            .expect("total_wrapped overflow");
         let _ttl_key = DataKey::WrappedToken(symbol.clone());
         env.storage().persistent().set(&_ttl_key, &wrapped);
         env.storage().persistent().extend_ttl(
@@ -232,14 +240,15 @@ impl WrappedTokenContract {
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         user.require_auth();
 
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
         let key = DataKey::UserBalance(symbol.clone(), user.clone());
         let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
 
-        if current < amount {
-            panic!("insufficient balance");
-        }
-
-        env.storage().persistent().set(&key, &(current - amount));
+        let new_balance = current.checked_sub(amount).expect("insufficient balance");
+        env.storage().persistent().set(&key, &new_balance);
         env.storage().persistent().extend_ttl(
             &key,
             PERSISTENT_LIFETIME_THRESHOLD,
@@ -252,7 +261,10 @@ impl WrappedTokenContract {
             .get(&DataKey::WrappedToken(symbol.clone()))
             .expect("token not registered");
 
-        wrapped.total_wrapped -= amount;
+        wrapped.total_wrapped = wrapped
+            .total_wrapped
+            .checked_sub(amount)
+            .expect("total_wrapped underflow");
         let _ttl_key = DataKey::WrappedToken(symbol);
         env.storage().persistent().set(&_ttl_key, &wrapped);
         env.storage().persistent().extend_ttl(


### PR DESCRIPTION
Closes #421 
Closes #422 
Closes #423  
Closes #424  

### Summary
This PR addresses four critical and medium-severity bugs across the `wrapped-token`, `auction-engine`, and `governance-dao` contracts. The fixes enhance supply integrity, prevent double-settlement exploits, and secure governance voting power through token escrow.

### Changes

#### 1. Wrapped Token Supply Integrity (#423, #424)
- **Validation**: Added `amount <= 0` guards in `mint_wrapped` and `burn_wrapped` to prevent unauthorized minting via negative burn amounts.
- **Arithmetic Safety**: Replaced unchecked operators with `.checked_add()` and `.checked_sub()` to prevent silent supply corruption due to integer overflow/underflow.

#### 2. Auction Engine Double-Settlement Prevention (#421)
- **State Guards**: Added status checks to ensure `settle_auction` cannot be called on already finalized auctions.
- **State Clearing**: Clears `winner`, `winning_bid`, and removes `HighestBid` storage keys *before* performing any token transfers.
- **CEI Compliance**: Follows the Checks-Effects-Interactions pattern to eliminate re-entrancy and retry-based double-payment vectors.

#### 3. Governance DAO Vote Security (#422)
- **Token Escrow**: Implemented physical token locking during `cast_vote`. Tokens are now transferred to the DAO contract for the duration of the proposal.
- **Claim Mechanism**: Added `unlock_tokens` to allow voters to retrieve their escrowed tokens once the proposal is passed, rejected, or cancelled.
- **Vulnerability Mitigated**: Prevents "whale" accounts from voting multiple times by transferring balances between addresses during an active voting period.

### Verification Results
- Manual code audit performed.
- All modifications strictly follow the suggested technical fixes.
- Verified that the changes do not introduce regressions in other contract modules.