### PR TITLE
fix: resolve issues #436, #437, #438, #448

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ members = [
   "contracts/anomaly-detector",
   "contracts/common-admin",
   "contracts/vesting-schedule",
+  "contracts/access-control",
+  "contracts/treasury-manager",
+  "contracts/whitelist-registry",
 ]
 
 [workspace.dependencies]

--- a/contracts/access-control/Cargo.toml
+++ b/contracts/access-control/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pulsar-access-control"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+pulsar-common-admin = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils", "alloc"] }

--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -1,0 +1,163 @@
+//! PulsarTrack - Access Control (Soroban)
+//! Role-based access control with hierarchical role revocation on Stellar.
+//!
+//! Events:
+//! - ("access", "granted"): [account: Address, role: Role]
+//! - ("access", "revoked"): [account: Address, role: Role]
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum Role {
+    Operator,
+    Moderator,
+    Admin,
+    SuperAdmin,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    PendingAdmin,
+    Role(Address),
+}
+
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
+const INSTANCE_BUMP_AMOUNT: u32 = 86_400;
+const PERSISTENT_LIFETIME_THRESHOLD: u32 = 34_560;
+const PERSISTENT_BUMP_AMOUNT: u32 = 259_200;
+
+/// Returns a numeric rank for the role: higher = more privileged.
+fn role_rank(role: &Role) -> u32 {
+    match role {
+        Role::Operator => 1,
+        Role::Moderator => 2,
+        Role::Admin => 3,
+        Role::SuperAdmin => 4,
+    }
+}
+
+#[contract]
+pub struct AccessControlContract;
+
+#[contractimpl]
+impl AccessControlContract {
+    pub fn initialize(env: Env, admin: Address) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+
+        let _ttl_key = DataKey::Role(admin.clone());
+        env.storage()
+            .persistent()
+            .set(&_ttl_key, &Role::SuperAdmin);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+
+    pub fn grant_role(env: Env, caller: Address, account: Address, role: Role) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        caller.require_auth();
+
+        let caller_role = Self::_get_role(&env, &caller);
+        if role_rank(&caller_role) <= role_rank(&role) {
+            panic!("cannot grant a role equal to or higher than your own");
+        }
+
+        let _ttl_key = DataKey::Role(account.clone());
+        env.storage().persistent().set(&_ttl_key, &role);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        env.events().publish(
+            (symbol_short!("access"), symbol_short!("granted")),
+            (account, role),
+        );
+    }
+
+    pub fn revoke_role(env: Env, caller: Address, target: Address, role: Role) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        caller.require_auth();
+
+        let caller_role = Self::_get_role(&env, &caller);
+        let target_role = Self::_get_role(&env, &target);
+
+        // Enforce hierarchy: callers can only revoke roles strictly below their own.
+        // This prevents admins from revoking super-admins, or accidental self-lockout.
+        if role_rank(&caller_role) <= role_rank(&target_role) {
+            panic!("cannot revoke a role equal to or higher than your own");
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Role(target.clone()));
+
+        env.events().publish(
+            (symbol_short!("access"), symbol_short!("revoked")),
+            (target, role),
+        );
+    }
+
+    pub fn get_role(env: Env, account: Address) -> Role {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        Self::_get_role(&env, &account)
+    }
+
+    pub fn has_role(env: Env, account: Address, role: Role) -> bool {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        if let Some(stored) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Role>(&DataKey::Role(account))
+        {
+            stored == role
+        } else {
+            false
+        }
+    }
+
+    fn _get_role(env: &Env, account: &Address) -> Role {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Role>(&DataKey::Role(account.clone()))
+            .unwrap_or_else(|| panic!("account has no role"))
+    }
+
+    pub fn propose_admin(env: Env, current_admin: Address, new_admin: Address) {
+        pulsar_common_admin::propose_admin(
+            &env,
+            &DataKey::Admin,
+            &DataKey::PendingAdmin,
+            current_admin,
+            new_admin,
+        );
+    }
+
+    pub fn accept_admin(env: Env, new_admin: Address) {
+        pulsar_common_admin::accept_admin(&env, &DataKey::Admin, &DataKey::PendingAdmin, new_admin);
+    }
+}
+
+mod test;

--- a/contracts/access-control/src/test.rs
+++ b/contracts/access-control/src/test.rs
@@ -1,0 +1,108 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup(env: &Env) -> (AccessControlContractClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let id = env.register_contract(None, AccessControlContract);
+    let c = AccessControlContractClient::new(env, &id);
+    c.initialize(&admin);
+    (c, admin)
+}
+
+#[test]
+fn test_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    assert!(c.has_role(&admin, &Role::SuperAdmin));
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_initialize_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register_contract(None, AccessControlContract);
+    let c = AccessControlContractClient::new(&env, &id);
+    let a = Address::generate(&env);
+    c.initialize(&a);
+    c.initialize(&a);
+}
+
+#[test]
+fn test_grant_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    let account = Address::generate(&env);
+    c.grant_role(&admin, &account, &Role::Operator);
+    assert!(c.has_role(&account, &Role::Operator));
+}
+
+#[test]
+#[should_panic(expected = "cannot grant a role equal to or higher than your own")]
+fn test_grant_role_cannot_grant_equal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, super_admin) = setup(&env);
+    let admin_account = Address::generate(&env);
+    c.grant_role(&super_admin, &admin_account, &Role::Admin);
+
+    // Admin tries to grant another Admin role — should fail
+    let other = Address::generate(&env);
+    c.grant_role(&admin_account, &other, &Role::Admin);
+}
+
+#[test]
+fn test_revoke_role_lower_rank() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, super_admin) = setup(&env);
+    let operator = Address::generate(&env);
+    c.grant_role(&super_admin, &operator, &Role::Operator);
+    assert!(c.has_role(&operator, &Role::Operator));
+    c.revoke_role(&super_admin, &operator, &Role::Operator);
+    assert!(!c.has_role(&operator, &Role::Operator));
+}
+
+#[test]
+#[should_panic(expected = "cannot revoke a role equal to or higher than your own")]
+fn test_admin_cannot_revoke_super_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, super_admin) = setup(&env);
+    let admin_account = Address::generate(&env);
+    c.grant_role(&super_admin, &admin_account, &Role::Admin);
+
+    // Admin tries to revoke SuperAdmin — must panic
+    c.revoke_role(&admin_account, &super_admin, &Role::SuperAdmin);
+}
+
+#[test]
+#[should_panic(expected = "cannot revoke a role equal to or higher than your own")]
+fn test_admin_cannot_revoke_peer_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, super_admin) = setup(&env);
+    let admin_a = Address::generate(&env);
+    let admin_b = Address::generate(&env);
+    c.grant_role(&super_admin, &admin_a, &Role::Admin);
+    c.grant_role(&super_admin, &admin_b, &Role::Admin);
+
+    // admin_a tries to revoke admin_b (same rank) — must panic
+    c.revoke_role(&admin_a, &admin_b, &Role::Admin);
+}
+
+#[test]
+#[should_panic(expected = "cannot revoke a role equal to or higher than your own")]
+fn test_self_revocation_blocked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, super_admin) = setup(&env);
+    let admin_account = Address::generate(&env);
+    c.grant_role(&super_admin, &admin_account, &Role::Admin);
+
+    // Admin tries to revoke their own role — must panic (equal rank)
+    c.revoke_role(&admin_account, &admin_account, &Role::Admin);
+}

--- a/contracts/payout-automation/src/lib.rs
+++ b/contracts/payout-automation/src/lib.rs
@@ -158,6 +158,11 @@ impl PayoutAutomationContract {
                     last_payout: 0,
                 });
 
+        earnings.pending_amount = earnings
+            .pending_amount
+            .checked_add(amount)
+            .expect("pending_amount overflow");
+
         env.storage().persistent().set(&key, &earnings);
         env.storage().persistent().extend_ttl(
             &key,

--- a/contracts/treasury-manager/Cargo.toml
+++ b/contracts/treasury-manager/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pulsar-treasury-manager"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+pulsar-common-admin = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils", "alloc"] }

--- a/contracts/treasury-manager/src/lib.rs
+++ b/contracts/treasury-manager/src/lib.rs
@@ -1,0 +1,163 @@
+//! PulsarTrack - Treasury Manager (Soroban)
+//! Single-admin treasury for platform fund management on Stellar.
+//!
+//! Events:
+//! - ("treasury", "deposit"): [token: Address, amount: i128]
+//! - ("treasury", "withdraw"): [token: Address, recipient: Address, amount: i128]
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct TreasuryState {
+    pub balance: i128,
+    pub total_deposited: i128,
+    pub total_withdrawn: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    PendingAdmin,
+    State,
+    TokenAddress,
+}
+
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
+const INSTANCE_BUMP_AMOUNT: u32 = 86_400;
+
+#[contract]
+pub struct TreasuryManagerContract;
+
+#[contractimpl]
+impl TreasuryManagerContract {
+    pub fn initialize(env: Env, admin: Address, token: Address) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::TokenAddress, &token);
+        env.storage().instance().set(
+            &DataKey::State,
+            &TreasuryState {
+                balance: 0,
+                total_deposited: 0,
+                total_withdrawn: 0,
+            },
+        );
+    }
+
+    pub fn deposit(env: Env, sender: Address, amount: i128) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        sender.require_auth();
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let token: Address = env.storage().instance().get(&DataKey::TokenAddress).unwrap();
+        let token_client = token::Client::new(&env, &token);
+        token_client.transfer(&sender, &env.current_contract_address(), &amount);
+
+        let mut state: TreasuryState =
+            env.storage().instance().get(&DataKey::State).unwrap();
+        state.balance = state
+            .balance
+            .checked_add(amount)
+            .expect("balance overflow");
+        state.total_deposited = state
+            .total_deposited
+            .checked_add(amount)
+            .expect("total_deposited overflow");
+        env.storage().instance().set(&DataKey::State, &state);
+
+        env.events().publish(
+            (symbol_short!("treasury"), symbol_short!("deposit")),
+            (token, amount),
+        );
+    }
+
+    pub fn withdraw(env: Env, admin: Address, recipient: Address, amount: i128) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let token: Address = env.storage().instance().get(&DataKey::TokenAddress).unwrap();
+        let token_client = token::Client::new(&env, &token);
+
+        // Use the actual on-chain balance as the authoritative source so that
+        // any divergence between internal accounting and the real token balance
+        // (e.g. from a direct transfer or a prior accounting bug) cannot cause
+        // a panic inside token_client.transfer.
+        let actual_balance = token_client.balance(&env.current_contract_address());
+        if amount > actual_balance {
+            panic!("insufficient on-chain token balance");
+        }
+
+        token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+
+        // Sync internal accounting to reflect the actual post-withdrawal state.
+        let mut state: TreasuryState =
+            env.storage().instance().get(&DataKey::State).unwrap();
+        state.balance = actual_balance
+            .checked_sub(amount)
+            .expect("balance underflow");
+        state.total_withdrawn = state
+            .total_withdrawn
+            .checked_add(amount)
+            .expect("total_withdrawn overflow");
+        env.storage().instance().set(&DataKey::State, &state);
+
+        env.events().publish(
+            (symbol_short!("treasury"), symbol_short!("withdraw")),
+            (token, recipient, amount),
+        );
+    }
+
+    pub fn get_state(env: Env) -> TreasuryState {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        env.storage().instance().get(&DataKey::State).unwrap()
+    }
+
+    pub fn get_token(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        env.storage().instance().get(&DataKey::TokenAddress).unwrap()
+    }
+
+    pub fn propose_admin(env: Env, current_admin: Address, new_admin: Address) {
+        pulsar_common_admin::propose_admin(
+            &env,
+            &DataKey::Admin,
+            &DataKey::PendingAdmin,
+            current_admin,
+            new_admin,
+        );
+    }
+
+    pub fn accept_admin(env: Env, new_admin: Address) {
+        pulsar_common_admin::accept_admin(&env, &DataKey::Admin, &DataKey::PendingAdmin, new_admin);
+    }
+}
+
+mod test;

--- a/contracts/treasury-manager/src/test.rs
+++ b/contracts/treasury-manager/src/test.rs
@@ -1,0 +1,90 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env, IntoVal,
+};
+
+fn setup(env: &Env) -> (TreasuryManagerContractClient<'_>, Address, Address) {
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_addr = token_id.address();
+
+    let id = env.register_contract(None, TreasuryManagerContract);
+    let c = TreasuryManagerContractClient::new(env, &id);
+    env.mock_all_auths();
+    c.initialize(&admin, &token_addr);
+    (c, admin, token_addr)
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+#[test]
+fn test_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _admin, token) = setup(&env);
+    assert_eq!(c.get_token(), token);
+    let state = c.get_state();
+    assert_eq!(state.balance, 0);
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_initialize_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin, token) = setup(&env);
+    c.initialize(&admin, &token);
+}
+
+#[test]
+fn test_deposit_and_withdraw() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin, token) = setup(&env);
+    let contract_id = c.address.clone();
+
+    mint(&env, &token, &admin, 1_000);
+
+    c.deposit(&admin, &1_000i128);
+    assert_eq!(c.get_state().balance, 1_000);
+
+    let recipient = Address::generate(&env);
+    c.withdraw(&admin, &recipient, &400i128);
+
+    let state = c.get_state();
+    assert_eq!(state.balance, 600);
+    assert_eq!(state.total_withdrawn, 400);
+
+    let token_client = TokenClient::new(&env, &token);
+    assert_eq!(token_client.balance(&recipient), 400);
+    assert_eq!(token_client.balance(&contract_id), 600);
+}
+
+#[test]
+#[should_panic(expected = "insufficient on-chain token balance")]
+fn test_withdraw_rejects_overdraft() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin, token) = setup(&env);
+    mint(&env, &token, &admin, 500);
+    c.deposit(&admin, &500i128);
+    // Try to withdraw more than what's actually on-chain
+    c.withdraw(&admin, &admin, &600i128);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_withdraw_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _admin, token) = setup(&env);
+    let stranger = Address::generate(&env);
+    mint(&env, &token, &stranger, 100);
+    c.withdraw(&stranger, &stranger, &50i128);
+}

--- a/contracts/whitelist-registry/Cargo.toml
+++ b/contracts/whitelist-registry/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pulsar-whitelist-registry"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+pulsar-common-admin = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils", "alloc"] }

--- a/contracts/whitelist-registry/src/lib.rs
+++ b/contracts/whitelist-registry/src/lib.rs
@@ -1,0 +1,215 @@
+//! PulsarTrack - Whitelist Registry (Soroban)
+//! Address whitelist management with grace-period removal on Stellar.
+//!
+//! Removing an address is a two-phase operation:
+//!   1. `remove_from_whitelist` marks the entry with `removal_scheduled_at`.
+//!   2. `is_whitelisted` returns false only after GRACE_PERIOD_SECS have elapsed,
+//!      allowing in-flight operations against the address to complete safely.
+//!
+//! Events:
+//! - ("whitelist", "added"):   [list_type: ListType, address: Address]
+//! - ("whitelist", "removal"): [list_type: ListType, address: Address, effective_at: u64]
+//! - ("whitelist", "purged"):  [list_type: ListType, address: Address]
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+/// 24-hour grace window between scheduling removal and the entry becoming invalid.
+const GRACE_PERIOD_SECS: u64 = 86_400;
+
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
+const INSTANCE_BUMP_AMOUNT: u32 = 86_400;
+const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
+const PERSISTENT_BUMP_AMOUNT: u32 = 1_051_200;
+
+#[contracttype]
+#[derive(Clone, PartialEq)]
+pub enum ListType {
+    Publisher,
+    Advertiser,
+    Oracle,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct WhitelistEntry {
+    pub address: Address,
+    pub list_type: ListType,
+    pub added_at: u64,
+    /// When set, the address will be treated as de-whitelisted after this timestamp.
+    pub removal_scheduled_at: Option<u64>,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    PendingAdmin,
+    Whitelist(ListType, Address),
+}
+
+#[contract]
+pub struct WhitelistRegistryContract;
+
+#[contractimpl]
+impl WhitelistRegistryContract {
+    pub fn initialize(env: Env, admin: Address) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn add_to_whitelist(env: Env, admin: Address, address: Address, list_type: ListType) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+
+        let entry = WhitelistEntry {
+            address: address.clone(),
+            list_type: list_type.clone(),
+            added_at: env.ledger().timestamp(),
+            removal_scheduled_at: None,
+        };
+
+        let _ttl_key = DataKey::Whitelist(list_type.clone(), address.clone());
+        env.storage().persistent().set(&_ttl_key, &entry);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        env.events().publish(
+            (symbol_short!("whitelist"), symbol_short!("added")),
+            (list_type, address),
+        );
+    }
+
+    /// Schedule removal with a grace period so that in-flight operations relying
+    /// on this address's whitelisted status are not abruptly broken mid-execution.
+    pub fn remove_from_whitelist(env: Env, admin: Address, address: Address, list_type: ListType) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+
+        let key = DataKey::Whitelist(list_type.clone(), address.clone());
+        let mut entry: WhitelistEntry = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("address not whitelisted");
+
+        // Idempotent: if removal is already scheduled, leave the existing timestamp.
+        if entry.removal_scheduled_at.is_none() {
+            entry.removal_scheduled_at =
+                Some(env.ledger().timestamp().saturating_add(GRACE_PERIOD_SECS));
+        }
+
+        let effective_at = entry.removal_scheduled_at.unwrap();
+        env.storage().persistent().set(&key, &entry);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+
+        env.events().publish(
+            (symbol_short!("whitelist"), symbol_short!("removal")),
+            (list_type, address, effective_at),
+        );
+    }
+
+    /// Permanently delete an entry whose grace period has already expired.
+    pub fn purge_entry(env: Env, address: Address, list_type: ListType) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        let key = DataKey::Whitelist(list_type.clone(), address.clone());
+        let entry: WhitelistEntry = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("address not whitelisted");
+
+        let effective_at = entry
+            .removal_scheduled_at
+            .expect("removal not scheduled for this address");
+
+        if env.ledger().timestamp() < effective_at {
+            panic!("grace period has not elapsed yet");
+        }
+
+        env.storage().persistent().remove(&key);
+
+        env.events().publish(
+            (symbol_short!("whitelist"), symbol_short!("purged")),
+            (list_type, address),
+        );
+    }
+
+    /// Returns true only when the address is whitelisted AND its grace period
+    /// has not yet expired (or removal has not been scheduled at all).
+    pub fn is_whitelisted(env: Env, address: Address, list_type: ListType) -> bool {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+
+        if let Some(entry) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, WhitelistEntry>(&DataKey::Whitelist(list_type, address))
+        {
+            match entry.removal_scheduled_at {
+                None => true,
+                Some(effective_at) => env.ledger().timestamp() < effective_at,
+            }
+        } else {
+            false
+        }
+    }
+
+    pub fn get_entry(
+        env: Env,
+        address: Address,
+        list_type: ListType,
+    ) -> Option<WhitelistEntry> {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        env.storage()
+            .persistent()
+            .get(&DataKey::Whitelist(list_type, address))
+    }
+
+    pub fn propose_admin(env: Env, current_admin: Address, new_admin: Address) {
+        pulsar_common_admin::propose_admin(
+            &env,
+            &DataKey::Admin,
+            &DataKey::PendingAdmin,
+            current_admin,
+            new_admin,
+        );
+    }
+
+    pub fn accept_admin(env: Env, new_admin: Address) {
+        pulsar_common_admin::accept_admin(&env, &DataKey::Admin, &DataKey::PendingAdmin, new_admin);
+    }
+}
+
+mod test;

--- a/contracts/whitelist-registry/src/test.rs
+++ b/contracts/whitelist-registry/src/test.rs
@@ -1,0 +1,141 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env,
+};
+
+fn setup(env: &Env) -> (WhitelistRegistryContractClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let id = env.register_contract(None, WhitelistRegistryContract);
+    let c = WhitelistRegistryContractClient::new(env, &id);
+    c.initialize(&admin);
+    (c, admin)
+}
+
+#[test]
+fn test_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    setup(&env);
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_initialize_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    c.initialize(&admin);
+}
+
+#[test]
+fn test_add_and_is_whitelisted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    let addr = Address::generate(&env);
+    c.add_to_whitelist(&admin, &addr, &ListType::Publisher);
+    assert!(c.is_whitelisted(&addr, &ListType::Publisher));
+}
+
+#[test]
+fn test_remove_schedules_grace_period() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    let addr = Address::generate(&env);
+    c.add_to_whitelist(&admin, &addr, &ListType::Publisher);
+
+    c.remove_from_whitelist(&admin, &addr, &ListType::Publisher);
+
+    // Still whitelisted during grace period
+    assert!(c.is_whitelisted(&addr, &ListType::Publisher));
+
+    let entry = c.get_entry(&addr, &ListType::Publisher).unwrap();
+    assert!(entry.removal_scheduled_at.is_some());
+}
+
+#[test]
+fn test_is_whitelisted_false_after_grace_period() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    let addr = Address::generate(&env);
+    c.add_to_whitelist(&admin, &addr, &ListType::Publisher);
+    c.remove_from_whitelist(&admin, &addr, &ListType::Publisher);
+
+    // Advance ledger time past the grace period
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + GRACE_PERIOD_SECS + 1,
+        protocol_version: env.ledger().protocol_version(),
+        sequence_number: env.ledger().sequence(),
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 4096,
+        max_entry_ttl: 6_312_000,
+    });
+
+    assert!(!c.is_whitelisted(&addr, &ListType::Publisher));
+}
+
+#[test]
+fn test_purge_after_grace_period() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    let addr = Address::generate(&env);
+    c.add_to_whitelist(&admin, &addr, &ListType::Publisher);
+    c.remove_from_whitelist(&admin, &addr, &ListType::Publisher);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + GRACE_PERIOD_SECS + 1,
+        protocol_version: env.ledger().protocol_version(),
+        sequence_number: env.ledger().sequence(),
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 4096,
+        max_entry_ttl: 6_312_000,
+    });
+
+    c.purge_entry(&addr, &ListType::Publisher);
+    assert!(c.get_entry(&addr, &ListType::Publisher).is_none());
+}
+
+#[test]
+#[should_panic(expected = "grace period has not elapsed yet")]
+fn test_purge_before_grace_period_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    let addr = Address::generate(&env);
+    c.add_to_whitelist(&admin, &addr, &ListType::Publisher);
+    c.remove_from_whitelist(&admin, &addr, &ListType::Publisher);
+    // Attempt purge immediately — should panic
+    c.purge_entry(&addr, &ListType::Publisher);
+}
+
+#[test]
+fn test_remove_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    let addr = Address::generate(&env);
+    c.add_to_whitelist(&admin, &addr, &ListType::Publisher);
+    c.remove_from_whitelist(&admin, &addr, &ListType::Publisher);
+    let first = c
+        .get_entry(&addr, &ListType::Publisher)
+        .unwrap()
+        .removal_scheduled_at;
+
+    // Second call must not update the scheduled timestamp
+    c.remove_from_whitelist(&admin, &addr, &ListType::Publisher);
+    let second = c
+        .get_entry(&addr, &ListType::Publisher)
+        .unwrap()
+        .removal_scheduled_at;
+
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
## Summary

### Issue #448 — payout-automation: `schedule_payout` never increments `pending_amount`
- Added `checked_add(amount)` to `earnings.pending_amount` before persisting the record in `schedule_payout`.
- Without this, `pending_amount` stayed at 0 and `execute_payout` always panicked with an underflow on `checked_sub`.

### Issue #436 — access-control: role revocation ignores role hierarchy
- New contract `contracts/access-control` with a `Role` hierarchy (`Operator → Moderator → Admin → SuperAdmin`).
- `revoke_role` now calls `role_rank()` to compare caller and target ranks; callers can only revoke roles **strictly below** their own.
- Prevents any Admin from revoking a peer Admin or SuperAdmin, and blocks accidental self-revocation.

### Issue #437 — treasury-manager: withdrawal not checked against on-chain token balance
- New contract `contracts/treasury-manager` with a single-admin `withdraw` function.
- Before calling `token_client.transfer`, the function reads `token_client.balance(&env.current_contract_address())` and panics if `amount > actual_balance`.
- Internal accounting is then synced from the real on-chain balance, preventing permanent inflation.

### Issue #438 — whitelist-registry: `remove_from_whitelist` immediately deletes entries
- New contract `contracts/whitelist-registry` with `WhitelistEntry { removal_scheduled_at: Option<u64> }`.
- `remove_from_whitelist` schedules removal 24 hours (`GRACE_PERIOD_SECS = 86_400`) in the future instead of deleting immediately.
- `is_whitelisted` returns `false` only after the grace period expires, keeping in-flight operations safe.
- `purge_entry` permanently deletes entries after the grace period has elapsed.
- Removal is idempotent: a second call does not update an already-scheduled timestamp.


Closes #436
Closes #437
Closes #438
Closes #448