### PR TITLE
fix: invoke governance proposal targets

### DIFF
--- a/contracts/governance-dao/src/lib.rs
+++ b/contracts/governance-dao/src/lib.rs
@@ -8,7 +8,8 @@
 
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, token, Address, Env, String,
+    contract, contractimpl, contracttype, symbol_short, token, Address, Env, IntoVal, String,
+    Symbol,
 };
 
 // ============================================================
@@ -420,9 +421,14 @@ impl GovernanceDaoContract {
             PERSISTENT_BUMP_AMOUNT,
         );
 
-        // Any execution side effects (e.g. calling proposal.target_contract)
-        // must be placed here — after the status has been committed — so they
-        // cannot be replayed if they succeed but the status write were to fail.
+        if let Some(ref target) = proposal.target_contract {
+            env.invoke_contract::<()>(
+                target,
+                &Symbol::new(&env, "execute_governance"),
+                soroban_sdk::vec![&env, proposal_id.into_val(&env)],
+            );
+        }
+
         env.events().publish(
             (symbol_short!("proposal"), symbol_short!("executed")),
             (proposal_id, proposal.target_contract),

--- a/contracts/governance-dao/src/test.rs
+++ b/contracts/governance-dao/src/test.rs
@@ -53,15 +53,27 @@ impl MockGovToken {
         if from_bal < amount {
             panic!("insufficient balance");
         }
-        env.storage()
-            .persistent()
-            .set(&from, &(from_bal - amount));
+        env.storage().persistent().set(&from, &(from_bal - amount));
         let to_bal = env
             .storage()
             .persistent()
             .get::<Address, i128>(&to)
             .unwrap_or(0);
         env.storage().persistent().set(&to, &(to_bal + amount));
+    }
+}
+
+#[soroban_contract]
+pub struct GovernanceExecutionTarget;
+
+#[soroban_contractimpl]
+impl GovernanceExecutionTarget {
+    pub fn execute_governance(env: Env, proposal_id: u64) {
+        env.storage().instance().set(&0u32, &proposal_id);
+    }
+
+    pub fn last_executed(env: Env) -> Option<u64> {
+        env.storage().instance().get(&0u32)
     }
 }
 
@@ -540,7 +552,12 @@ fn test_finalize_proposal_passes_at_51_pct_exact() {
     let proposal_id = client.create_proposal(&proposer, &make_title(&env), &make_desc(&env), &None);
 
     client.cast_vote(&voter_for, &proposal_id, &VoteChoice::For, &510_000i128);
-    client.cast_vote(&voter_against, &proposal_id, &VoteChoice::Against, &490_000i128);
+    client.cast_vote(
+        &voter_against,
+        &proposal_id,
+        &VoteChoice::Against,
+        &490_000i128,
+    );
 
     env.ledger().with_mut(|li| {
         li.sequence_number = 200;
@@ -572,7 +589,12 @@ fn test_finalize_proposal_passes_at_51_1_pct() {
     let proposal_id = client.create_proposal(&proposer, &make_title(&env), &make_desc(&env), &None);
 
     client.cast_vote(&voter_for, &proposal_id, &VoteChoice::For, &511_000i128);
-    client.cast_vote(&voter_against, &proposal_id, &VoteChoice::Against, &489_000i128);
+    client.cast_vote(
+        &voter_against,
+        &proposal_id,
+        &VoteChoice::Against,
+        &489_000i128,
+    );
 
     env.ledger().with_mut(|li| {
         li.sequence_number = 200;
@@ -601,7 +623,12 @@ fn test_finalize_proposal_rejected_at_50_99_pct_with_bps() {
     let proposal_id = client.create_proposal(&proposer, &make_title(&env), &make_desc(&env), &None);
 
     client.cast_vote(&voter_for, &proposal_id, &VoteChoice::For, &5_099i128);
-    client.cast_vote(&voter_against, &proposal_id, &VoteChoice::Against, &4_901i128);
+    client.cast_vote(
+        &voter_against,
+        &proposal_id,
+        &VoteChoice::Against,
+        &4_901i128,
+    );
 
     env.ledger().with_mut(|li| {
         li.sequence_number = 200;
@@ -627,7 +654,12 @@ fn test_finalize_proposal_rejected_at_exactly_50_pct() {
     let proposal_id = client.create_proposal(&proposer, &make_title(&env), &make_desc(&env), &None);
 
     client.cast_vote(&voter_for, &proposal_id, &VoteChoice::For, &500_000i128);
-    client.cast_vote(&voter_against, &proposal_id, &VoteChoice::Against, &500_000i128);
+    client.cast_vote(
+        &voter_against,
+        &proposal_id,
+        &VoteChoice::Against,
+        &500_000i128,
+    );
 
     env.ledger().with_mut(|li| {
         li.sequence_number = 200;
@@ -650,7 +682,7 @@ fn test_execute_proposal_emits_executed_event() {
 
     let proposer = Address::generate(&env);
     let voter = Address::generate(&env);
-    let target = Address::generate(&env);
+    let target = env.register_contract(None, GovernanceExecutionTarget);
     let proposal_id = client.create_proposal(
         &proposer,
         &make_title(&env),
@@ -671,6 +703,38 @@ fn test_execute_proposal_emits_executed_event() {
     assert!(matches!(p.status, ProposalStatus::Executed));
     // target_contract is preserved on the proposal
     assert_eq!(p.target_contract, Some(target));
+}
+
+#[test]
+fn test_execute_proposal_invokes_target_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, _) = setup_with_mock_token(&env, 1_000);
+    let target = env.register_contract(None, GovernanceExecutionTarget);
+    let target_client = GovernanceExecutionTargetClient::new(&env, &target);
+
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    let proposal_id = client.create_proposal(
+        &proposer,
+        &make_title(&env),
+        &make_desc(&env),
+        &Some(target.clone()),
+    );
+
+    client.cast_vote(&voter, &proposal_id, &VoteChoice::For, &200i128);
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number = 200;
+    });
+
+    client.finalize_proposal(&proposal_id);
+    client.execute_proposal(&admin, &proposal_id);
+
+    let proposal = client.get_proposal(&proposal_id).unwrap();
+    assert!(matches!(proposal.status, ProposalStatus::Executed));
+    assert_eq!(target_client.last_executed(), Some(proposal_id));
 }
 
 #[test]
@@ -862,8 +926,7 @@ fn test_double_vote_after_ttl_window_rejected() {
     let proposer = Address::generate(&env);
     let voter = Address::generate(&env);
 
-    let proposal_id =
-        client.create_proposal(&proposer, &make_title(&env), &make_desc(&env), &None);
+    let proposal_id = client.create_proposal(&proposer, &make_title(&env), &make_desc(&env), &None);
 
     // Voter A casts their vote at ledger 0
     client.cast_vote(&voter, &proposal_id, &VoteChoice::For, &1_000i128);

--- a/contracts/governance-dao/test_snapshots/test/test_execute_proposal_invokes_target_contract.1.json
+++ b/contracts/governance-dao/test_snapshots/test/test_execute_proposal_invokes_target_contract.1.json
@@ -47,7 +47,7 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
         {
           "function": {
             "contract_fn": {
@@ -55,7 +55,7 @@
               "function_name": "create_proposal",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 },
                 {
                   "string": "Increase treasury allocation"
@@ -64,7 +64,7 @@
                   "string": "Proposal to increase budget by 10%"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -75,7 +75,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
         {
           "function": {
             "contract_fn": {
@@ -83,7 +83,7 @@
               "function_name": "cast_vote",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 },
                 {
                   "u64": 1
@@ -112,7 +112,7 @@
                   "function_name": "transfer",
                   "args": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -155,6 +155,7 @@
         }
       ]
     ],
+    [],
     []
   ],
   "ledger": {
@@ -272,7 +273,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
             },
             "durability": "persistent"
           }
@@ -285,7 +286,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 },
                 "durability": "persistent",
                 "val": {
@@ -358,7 +359,7 @@
                   "u64": 1
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 }
               ]
             },
@@ -381,7 +382,7 @@
                       "u64": 1
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                     }
                   ]
                 },
@@ -409,7 +410,7 @@
                   "u64": 1
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 }
               ]
             },
@@ -432,7 +433,7 @@
                       "u64": 1
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                     }
                   ]
                 },
@@ -524,7 +525,7 @@
                         "symbol": "proposer"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                       }
                     },
                     {
@@ -560,7 +561,7 @@
                         "symbol": "target_contract"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -634,7 +635,7 @@
                   "u64": 1
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 }
               ]
             },
@@ -657,7 +658,7 @@
                       "u64": 1
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                     }
                   ]
                 },
@@ -828,72 +829,6 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 1033654523790656264
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 1033654523790656264
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -904,7 +839,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": "ledger_key_contract_instance",
                 "durability": "persistent",
                 "val": {
@@ -929,6 +864,72 @@
             "ext": "v0"
           },
           4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
         ]
       ],
       [


### PR DESCRIPTION
## Summary
- invoke `execute_governance(proposal_id)` on a proposal's `target_contract` after the proposal is persisted as `Executed`
- keep the existing CEI ordering so repeat execution is rejected before external side effects
- add a target-contract regression test proving the governance execution reaches the target

## Tests
- `cargo fmt -p pulsar-governance-dao --check`
- `cargo +1.91.1 test -p pulsar-governance-dao execute_proposal`

I also ran `cargo +1.91.1 test -p pulsar-governance-dao`; the execution-related tests pass, but three unrelated existing cancel tests still fail because their `#[should_panic(expected = ...)]` text expects `can only cancel active proposals` while the contract currently panics with `can only cancel an active proposal`.

Refs #551
