### PR TITLE
fix: validate governance params, extend oracle TTL, block shill bids,…

### DIFF
--- a/contracts/auction-engine/src/lib.rs
+++ b/contracts/auction-engine/src/lib.rs
@@ -162,6 +162,10 @@ impl AuctionEngineContract {
             .get(&DataKey::Auction(auction_id))
             .expect("auction not found");
 
+        if bidder == auction.publisher {
+            panic!("publisher cannot bid on own auction");
+        }
+
         if auction.status != AuctionStatus::Open {
             panic!("auction not open");
         }

--- a/contracts/creative-marketplace/src/lib.rs
+++ b/contracts/creative-marketplace/src/lib.rs
@@ -222,7 +222,7 @@ impl CreativeMarketplaceContract {
         let token_client = token::Client::new(&env, &token_addr);
 
         let now = env.ledger().timestamp();
-        let expires_at = license_duration_secs.map(|d| now + d);
+        let expires_at = license_duration_secs.map(|d| now.checked_add(d).expect("license expiry timestamp overflows u64"));
 
         let license = License {
             listing_id,

--- a/contracts/governance-dao/src/lib.rs
+++ b/contracts/governance-dao/src/lib.rs
@@ -112,6 +112,12 @@ impl GovernanceDaoContract {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
         }
+        if quorum_bps == 0 {
+            panic!("quorum must be > 0");
+        }
+        if pass_threshold == 0 || pass_threshold > 100 {
+            panic!("pass_threshold must be 1-100");
+        }
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage()

--- a/contracts/oracle-integration/src/lib.rs
+++ b/contracts/oracle-integration/src/lib.rs
@@ -227,11 +227,11 @@ impl OracleIntegrationContract {
     }
 
     fn _require_oracle(env: &Env, oracle: &Address) {
-        let is_auth: bool = env
-            .storage()
-            .persistent()
-            .get(&DataKey::AuthorizedOracle(oracle.clone()))
-            .unwrap_or(false);
+        let key = DataKey::AuthorizedOracle(oracle.clone());
+        let is_auth: bool = env.storage().persistent().get(&key).unwrap_or(false);
+        if is_auth {
+            env.storage().persistent().extend_ttl(&key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+        }
         if !is_auth {
             panic!("not authorized oracle");
         }


### PR DESCRIPTION
… guard license expiry overflow

- governance-dao #565: reject quorum_bps=0 and pass_threshold outside 1-100 in initialize
- oracle-integration #561: extend_ttl on AuthorizedOracle key each time _require_oracle is called
- auction-engine #562: prevent publisher from bidding on their own auction in place_bid
- creative-marketplace #563: use checked_add for license expiry to prevent u64 overflow

Closes #561 
Closes #562 
Closes #563 
Closes #565 
