### PR TITLE
fix: add auth guard, validate inputs, fix slash cooldown and node count bugs

### DIFF
--- a/contracts/publisher-network/src/lib.rs
+++ b/contracts/publisher-network/src/lib.rs
@@ -93,6 +93,13 @@ impl PublisherNetworkContract {
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         publisher.require_auth();
 
+        if capacity == 0 {
+            panic!("capacity must be positive");
+        }
+        if min_cpm <= 0 {
+            panic!("min_cpm must be positive");
+        }
+
         if env
             .storage()
             .persistent()
@@ -237,8 +244,18 @@ impl PublisherNetworkContract {
         if stats.active_nodes > 0 {
             stats.active_nodes -= 1;
         }
+        stats.total_nodes = stats.total_nodes.saturating_sub(1);
         stats.total_capacity = stats.total_capacity.saturating_sub(node.capacity);
         env.storage().instance().set(&DataKey::NetworkStats, &stats);
+
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NodeCount)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::NodeCount, &count.saturating_sub(1));
     }
 
     pub fn record_impression(env: Env, _publisher: Address) {

--- a/contracts/publisher-network/src/test.rs
+++ b/contracts/publisher-network/src/test.rs
@@ -226,3 +226,108 @@ fn test_set_fraud_contract_unauthorized() {
     let (c, _) = setup(&env);
     c.set_fraud_contract(&Address::generate(&env), &Address::generate(&env));
 }
+
+#[test]
+#[should_panic(expected = "capacity must be positive")]
+fn test_join_network_zero_capacity() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _) = setup(&env);
+    let pub1 = Address::generate(&env);
+    let cats = vec![&env, s(&env, "tech")];
+    c.join_network(
+        &pub1,
+        &NodeType::Standard,
+        &0u64,
+        &100i128,
+        &s(&env, "US"),
+        &cats,
+    );
+}
+
+#[test]
+#[should_panic(expected = "min_cpm must be positive")]
+fn test_join_network_zero_min_cpm() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _) = setup(&env);
+    let pub1 = Address::generate(&env);
+    let cats = vec![&env, s(&env, "tech")];
+    c.join_network(
+        &pub1,
+        &NodeType::Standard,
+        &10_000u64,
+        &0i128,
+        &s(&env, "US"),
+        &cats,
+    );
+}
+
+#[test]
+#[should_panic(expected = "min_cpm must be positive")]
+fn test_join_network_negative_min_cpm() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _) = setup(&env);
+    let pub1 = Address::generate(&env);
+    let cats = vec![&env, s(&env, "tech")];
+    c.join_network(
+        &pub1,
+        &NodeType::Standard,
+        &10_000u64,
+        &-1i128,
+        &s(&env, "US"),
+        &cats,
+    );
+}
+
+#[test]
+fn test_deactivate_decrements_node_count_and_total_nodes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _) = setup(&env);
+    let pub1 = Address::generate(&env);
+    let cats = vec![&env, s(&env, "tech")];
+    c.join_network(
+        &pub1,
+        &NodeType::Standard,
+        &10_000u64,
+        &100i128,
+        &s(&env, "US"),
+        &cats,
+    );
+    assert_eq!(c.get_node_count(), 1);
+    assert_eq!(c.get_network_stats().total_nodes, 1);
+
+    c.deactivate(&pub1);
+
+    assert_eq!(c.get_node_count(), 0);
+    assert_eq!(c.get_network_stats().total_nodes, 0);
+    assert_eq!(c.get_network_stats().active_nodes, 0);
+}
+
+#[test]
+fn test_suspend_decrements_node_count_and_total_nodes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    let fraud = Address::generate(&env);
+    c.set_fraud_contract(&admin, &fraud);
+    let pub1 = Address::generate(&env);
+    let cats = vec![&env, s(&env, "tech")];
+    c.join_network(
+        &pub1,
+        &NodeType::Standard,
+        &10_000u64,
+        &100i128,
+        &s(&env, "US"),
+        &cats,
+    );
+    assert_eq!(c.get_node_count(), 1);
+    assert_eq!(c.get_network_stats().total_nodes, 1);
+
+    c.suspend_publisher(&fraud, &pub1);
+
+    assert_eq!(c.get_node_count(), 0);
+    assert_eq!(c.get_network_stats().total_nodes, 0);
+}

--- a/contracts/publisher-reputation/src/lib.rs
+++ b/contracts/publisher-reputation/src/lib.rs
@@ -46,6 +46,7 @@ const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
 const INSTANCE_BUMP_AMOUNT: u32 = 86_400;
 const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
 const PERSISTENT_BUMP_AMOUNT: u32 = 1_051_200;
+const SLASH_COOLDOWN_LEDGERS: u32 = 17_280; // ~1 day at 5 s/ledger
 
 #[contract]
 pub struct PublisherReputationContract;
@@ -70,6 +71,7 @@ impl PublisherReputationContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        publisher.require_auth();
         if env
             .storage()
             .persistent()
@@ -209,7 +211,7 @@ impl PublisherReputationContract {
             .expect("publisher not registered");
 
         let current_ledger = env.ledger().sequence();
-        if current_ledger <= rep.last_slash_ledger + 100 {
+        if current_ledger <= rep.last_slash_ledger + SLASH_COOLDOWN_LEDGERS {
             panic!("slash cooldown active");
         }
 

--- a/contracts/publisher-reputation/src/test.rs
+++ b/contracts/publisher-reputation/src/test.rs
@@ -133,13 +133,53 @@ fn test_slash_publisher() {
     c.init_publisher(&pub1);
 
     env.ledger().with_mut(|li| {
-        li.sequence_number += 105;
+        li.sequence_number += 17_281;
     });
 
     c.slash_publisher(&oracle, &pub1, &100u32);
     let rep = c.get_reputation(&pub1).unwrap();
     assert_eq!(rep.score, 400); // 500 - 100
     assert_eq!(rep.slashes, 1);
+}
+
+#[test]
+#[should_panic(expected = "slash cooldown active")]
+fn test_slash_publisher_cooldown_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _, oracle) = setup(&env);
+    let pub1 = Address::generate(&env);
+    c.init_publisher(&pub1);
+
+    env.ledger().with_mut(|li| {
+        li.sequence_number += 17_281;
+    });
+
+    c.slash_publisher(&oracle, &pub1, &50u32);
+
+    // Advance only 100 ledgers — still within the 17,280-ledger cooldown
+    env.ledger().with_mut(|li| {
+        li.sequence_number += 100;
+    });
+
+    c.slash_publisher(&oracle, &pub1, &50u32);
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_init_publisher_requires_auth() {
+    let env = Env::default();
+    // Do NOT mock_all_auths so the auth check fires
+    let id = env.register_contract(None, PublisherReputationContract);
+    let c = PublisherReputationContractClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    env.mock_all_auths();
+    c.initialize(&admin, &oracle);
+    let pub1 = Address::generate(&env);
+    // First call succeeds (all auths mocked), second must panic with duplicate
+    c.init_publisher(&pub1);
+    c.init_publisher(&pub1);
 }
 
 #[test]
@@ -162,7 +202,7 @@ fn test_slash_floor_at_zero() {
     c.init_publisher(&pub1);
 
     env.ledger().with_mut(|li| {
-        li.sequence_number += 105;
+        li.sequence_number += 17_281;
     });
 
     c.slash_publisher(&oracle, &pub1, &600u32); // capped at 100, so 500 - 100 = 400


### PR DESCRIPTION
## Summary

This PR fixes four security and correctness bugs across the `publisher-reputation` and `publisher-network` contracts.

---

### #582 — `init_publisher`: no auth check allows front-running

`init_publisher` had no `require_auth` guard, meaning any external actor could create a reputation record for any address before the real publisher did.

**Fix:** Added `publisher.require_auth()` before the duplicate-check so only the publisher themselves can initialise their own record.

---

### #583 — `slash_publisher`: 100-ledger cooldown is dangerously short

The slash cooldown was 100 ledgers (~8 minutes). A compromised oracle could drive a publisher's score from 500 to 0 in roughly 80 minutes with no defence.

**Fix:** Introduced the named constant `SLASH_COOLDOWN_LEDGERS = 17_280` (~1 day at 5 s/ledger) and replaced the hard-coded `100` with it. Updated existing slash tests to advance the ledger by `17_281` to satisfy the new threshold.

---

### #581 — `join_network`: accepts `capacity = 0` and `min_cpm <= 0`

No input validation meant publishers could register with zero capacity or a zero/negative floor price, corrupting `NetworkStats.total_capacity` and auction floor comparisons.

**Fix:** Added explicit guards at the top of `join_network`:
```rust
if capacity == 0 { panic!("capacity must be positive"); }
if min_cpm <= 0  { panic!("min_cpm must be positive"); }
```

---

### #580 — `_deactivate_node`: `NodeCount` and `total_nodes` never decremented

`_deactivate_node` correctly decremented `active_nodes` and `total_capacity` but left `NodeCount` (instance key) and `NetworkStats.total_nodes` unchanged. Over time these became permanent over-counts of all publishers who ever joined.

**Fix:**
```rust
stats.total_nodes = stats.total_nodes.saturating_sub(1);
let count: u64 = env.storage().instance().get(&DataKey::NodeCount).unwrap_or(0);
env.storage().instance().set(&DataKey::NodeCount, &count.saturating_sub(1));
```
Both are now decremented in `_deactivate_node`, which is called by both `deactivate` and `suspend_publisher`.

---

## Files Changed

- `contracts/publisher-reputation/src/lib.rs`
- `contracts/publisher-reputation/src/test.rs`
- `contracts/publisher-network/src/lib.rs`
- `contracts/publisher-network/src/test.rs`

## Test Coverage

- Updated `test_slash_publisher` and `test_slash_floor_at_zero` to use the 17,281-ledger advance.
- Added `test_slash_publisher_cooldown_enforced` — verifies the cooldown rejects a second slash within the window.
- Added `test_join_network_zero_capacity`, `test_join_network_zero_min_cpm`, `test_join_network_negative_min_cpm`.
- Added `test_deactivate_decrements_node_count_and_total_nodes` and `test_suspend_decrements_node_count_and_total_nodes`.

Closes #580
Closes #581
Closes #582
Closes #583