### PR TITLE
fix: enforce TTLs and guards; prevent KYC resubmission; allow per-campaign reviews (#584,#585,#586,#587)

### DIFF
--- a/contracts/identity-registry/src/lib.rs
+++ b/contracts/identity-registry/src/lib.rs
@@ -187,6 +187,13 @@ impl IdentityRegistryContract {
             }
         }
 
+        // Prevent verifying identities that are suspended or revoked
+        if identity.status == IdentityStatus::Suspended
+            || identity.status == IdentityStatus::Revoked
+        {
+            panic!("cannot verify a suspended or revoked identity");
+        }
+
         identity.status = IdentityStatus::Verified;
         identity.credentials_hash = credentials_hash;
         identity.verified_at = Some(env.ledger().timestamp());
@@ -259,18 +266,30 @@ impl IdentityRegistryContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
-        env.storage().persistent().get(&DataKey::Identity(account))
+        let key = DataKey::Identity(account.clone());
+        if let Some(identity) = env.storage().persistent().get::<DataKey, Identity>(&key) {
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+            Some(identity)
+        } else {
+            None
+        }
     }
 
     pub fn is_verified(env: Env, account: Address) -> bool {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
-        if let Some(identity) = env
-            .storage()
-            .persistent()
-            .get::<DataKey, Identity>(&DataKey::Identity(account))
-        {
+        let key = DataKey::Identity(account.clone());
+        if let Some(identity) = env.storage().persistent().get::<DataKey, Identity>(&key) {
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
             matches!(identity.status, IdentityStatus::Verified)
         } else {
             false
@@ -281,9 +300,17 @@ impl IdentityRegistryContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
-        env.storage()
-            .persistent()
-            .get(&DataKey::NameOwner(display_name))
+        let key = DataKey::NameOwner(display_name.clone());
+        if let Some(addr) = env.storage().persistent().get::<DataKey, Address>(&key) {
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_LIFETIME_THRESHOLD,
+                PERSISTENT_BUMP_AMOUNT,
+            );
+            Some(addr)
+        } else {
+            None
+        }
     }
 
     pub fn get_identity_count(env: Env) -> u64 {

--- a/contracts/kyc-registry/src/lib.rs
+++ b/contracts/kyc-registry/src/lib.rs
@@ -117,6 +117,21 @@ impl KycRegistryContract {
             panic!("provider not active");
         }
 
+        // If an existing verified record exists and is still valid, block resubmission
+        if let Some(existing) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, KycRecord>(&DataKey::KycRecord(account.clone()))
+        {
+            let still_valid = existing.verified
+                && existing
+                    .expires_at
+                    .map_or(true, |e| e > env.ledger().timestamp());
+            if still_valid {
+                panic!("existing verified kyc record must be revoked before re-submitting");
+            }
+        }
+
         let record = KycRecord {
             account: account.clone(),
             level: level.clone(),

--- a/contracts/publisher-reputation/src/lib.rs
+++ b/contracts/publisher-reputation/src/lib.rs
@@ -39,7 +39,7 @@ pub enum DataKey {
     Reputation(Address),
     Review(Address, u64), // publisher, review_index
     ReviewCount(Address),
-    ReviewRecord(Address, Address), // reviewer, publisher - to prevent duplicates
+    ReviewRecord(Address, Address, u64), // reviewer, publisher, campaign_id - to prevent duplicates per campaign
 }
 
 const INSTANCE_LIFETIME_THRESHOLD: u32 = 17_280;
@@ -118,10 +118,11 @@ impl PublisherReputationContract {
             panic!("invalid rating");
         }
 
-        // Check if reviewer has already submitted a review for this publisher
-        let review_key = DataKey::ReviewRecord(advertiser.clone(), publisher.clone());
-        if env.storage().persistent().has(&review_key) {
-            panic!("reviewer has already submitted a review for this publisher");
+        // Check if reviewer has already submitted a review for this publisher in this campaign
+        let review_key_check =
+            DataKey::ReviewRecord(advertiser.clone(), publisher.clone(), campaign_id);
+        if env.storage().persistent().has(&review_key_check) {
+            panic!("reviewer has already submitted a review for this publisher in this campaign");
         }
 
         let mut rep: ReputationScore = env
@@ -158,8 +159,8 @@ impl PublisherReputationContract {
             PERSISTENT_BUMP_AMOUNT,
         );
 
-        // Mark that this reviewer has reviewed this publisher
-        let review_key = DataKey::ReviewRecord(advertiser.clone(), publisher.clone());
+        // Mark that this reviewer has reviewed this publisher for this campaign
+        let review_key = DataKey::ReviewRecord(advertiser.clone(), publisher.clone(), campaign_id);
         env.storage().persistent().set(&review_key, &true);
         env.storage().persistent().extend_ttl(
             &review_key,


### PR DESCRIPTION
- **Summary:** Fixes logic and storage TTL issues across identity, KYC and publisher reputation contracts to prevent silent expiry, unintended state overwrites, and permanent review deduplication.
- **Changes:**
  - **Identity registry:** lib.rs — Add a guard in `verify_identity` to prevent verifying Suspended/Revoked identities; bump persistent TTLs after reads in `get_identity`, `is_verified`, and `get_by_name`.
  - **KYC registry:** lib.rs — Prevent `submit_kyc` from overwriting an existing verified & unexpired KYC record; require revocation before resubmission.
  - **Publisher reputation:** lib.rs — Change `DataKey::ReviewRecord` to include `campaign_id` and deduplicate per (advertiser, publisher, campaign) instead of lifetime-per-publisher.
- **Tests:** Unit tests run locally for the three crates — all passed:
  - `pulsar-identity-registry`: 17 passed
  - `pulsar-kyc-registry`: 14 passed
  - `pulsar-publisher-reputation`: 22 passed
- **Files modified (key):**
  - lib.rs
  - lib.rs
  - lib.rs

  - Closes #584
  - Closes #585
  - Closes #586
  - Closes #587