### PR TITLE
fix: privacy-layer and targeting-engine critical bugs (#597, #599, #5…

### DIFF
--- a/contracts/privacy-layer/src/lib.rs
+++ b/contracts/privacy-layer/src/lib.rs
@@ -121,7 +121,10 @@ impl PrivacyLayerContract {
             third_party_sharing,
             consent_hash: consent_hash.into(),
             consented_at: env.ledger().timestamp(),
-            expires_at: expires_in.map(|d| env.ledger().timestamp() + d),
+            expires_at: expires_in.map(|d| {
+                env.ledger().timestamp().checked_add(d)
+                    .expect("consent expiry timestamp overflows u64")
+            }),
         };
 
         let _ttl_key = DataKey::Consent(user.clone());
@@ -195,6 +198,7 @@ impl PrivacyLayerContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        admin.require_auth();
         
         // Check if a verifier is configured - if so, only verifier can verify
         let verifier: Option<Address> = env.storage().instance().get(&DataKey::Verifier).unwrap_or(None);
@@ -231,11 +235,17 @@ impl PrivacyLayerContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        let consent_key = DataKey::Consent(user.clone());
         if let Some(consent) = env
             .storage()
             .persistent()
-            .get::<DataKey, PrivacyConsent>(&DataKey::Consent(user))
+            .get::<DataKey, PrivacyConsent>(&consent_key)
         {
+            // Bump TTL on persistent consent entry
+            env.storage()
+                .persistent()
+                .extend_ttl(&consent_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+            
             // Check if consent has expired
             if let Some(expires) = consent.expires_at {
                 if expires <= env.ledger().timestamp() {
@@ -272,7 +282,16 @@ impl PrivacyLayerContract {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
-        env.storage().persistent().get(&DataKey::Consent(user))
+        let consent_key = DataKey::Consent(user.clone());
+        if let Some(consent) = env.storage().persistent().get::<DataKey, PrivacyConsent>(&consent_key) {
+            // Bump TTL on persistent consent entry
+            env.storage()
+                .persistent()
+                .extend_ttl(&consent_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
+            Some(consent)
+        } else {
+            None
+        }
     }
 
     pub fn get_proof(env: Env, proof_id: BytesN<32>) -> Option<AnonymousSegmentProof> {

--- a/contracts/targeting-engine/src/lib.rs
+++ b/contracts/targeting-engine/src/lib.rs
@@ -181,13 +181,18 @@ impl TargetingEngineContract {
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         oracle.require_auth();
 
+        let oracle_key = DataKey::AuthorizedOracle(oracle.clone());
         if !env
             .storage()
             .persistent()
-            .has(&DataKey::AuthorizedOracle(oracle.clone()))
+            .has(&oracle_key)
         {
             panic!("unauthorized");
         }
+        // Bump TTL on oracle authorization entry
+        env.storage()
+            .persistent()
+            .extend_ttl(&oracle_key, PERSISTENT_LIFETIME_THRESHOLD, PERSISTENT_BUMP_AMOUNT);
 
         if score > MAX_TARGETING_SCORE {
             panic!("score must be 0-1000");


### PR DESCRIPTION
Closes #599

---

Closes #597

---

Closes #594

---

Closes #592

---

…94, #592)

## Changes

### privacy-layer (#597, #599, #594)
- **#597**: Add TTL extension to has_consent and get_consent
  - Prevents consent records from silently expiring after ~61 days
  - Both functions now bump persistent storage TTL when reading consent

- **#599**: Add overflow guard to set_consent expires_at calculation
  - Prevent u64 overflow when large expires_in values wrap to past timestamp
  - Use checked_add with panic on overflow

- **#594**: Add admin.require_auth() to verify_zkp
  - Enforce cryptographic signature verification
  - Prevents unauthorized proofs from being marked as verified

### targeting-engine (#592)
- **#592**: Add TTL extension to compute_score authorization check
  - Prevents oracle authorization from silently expiring after ~61 days
  - Bump persistent storage TTL when validating oracle authorization

## Fixes
- close:#597
- close:#599
- close:#594
- close:#592