### PR TITLE
 Bug fixes: CEI violation in refund-processor, permissionless sync_balance in treasury-manager

### DIFF
--- a/contracts/refund-processor/src/lib.rs
+++ b/contracts/refund-processor/src/lib.rs
@@ -272,12 +272,8 @@ impl RefundProcessorContract {
         if balance < refund.amount_approved {
             panic!("insufficient contract balance for refund");
         }
-        token_client.transfer(
-            &env.current_contract_address(),
-            &refund.requester,
-            &refund.amount_approved,
-        );
 
+        // CEI: persist Processed status and remove pending marker before transfer
         refund.status = RefundStatus::Processed;
         let _ttl_key = DataKey::Refund(refund_id);
         env.storage().persistent().set(&_ttl_key, &refund);
@@ -288,6 +284,12 @@ impl RefundProcessorContract {
             &_ttl_key,
             PERSISTENT_LIFETIME_THRESHOLD,
             PERSISTENT_BUMP_AMOUNT,
+        );
+
+        token_client.transfer(
+            &env.current_contract_address(),
+            &refund.requester,
+            &refund.amount_approved,
         );
 
         env.events().publish(

--- a/contracts/treasury-manager/src/lib.rs
+++ b/contracts/treasury-manager/src/lib.rs
@@ -130,16 +130,10 @@ impl TreasuryManagerContract {
         );
     }
 
-    pub fn sync_balance(env: Env, admin: Address) {
+    pub fn sync_balance(env: Env) {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
-        admin.require_auth();
-        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        if admin != stored_admin {
-            panic!("unauthorized");
-        }
-
         let token: Address = env.storage().instance().get(&DataKey::TokenAddress).unwrap();
         let actual = token::Client::new(&env, &token).balance(&env.current_contract_address());
         let mut state: TreasuryState =

--- a/contracts/treasury-manager/src/test.rs
+++ b/contracts/treasury-manager/src/test.rs
@@ -93,23 +93,25 @@ fn test_withdraw_unauthorized() {
 fn test_sync_balance() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, admin, token) = setup(&env);
+    let (c, _admin, token) = setup(&env);
     let contract_id = c.address.clone();
 
     mint(&env, &token, &contract_id, 1_000);
     assert_eq!(c.get_state().balance, 0);
 
-    c.sync_balance(&admin);
+    c.sync_balance();
     assert_eq!(c.get_state().balance, 1_000);
 }
 
 #[test]
-#[should_panic(expected = "unauthorized")]
-fn test_sync_balance_unauthorized() {
+fn test_sync_balance_permissionless() {
     let env = Env::default();
     env.mock_all_auths();
     let (c, _admin, token) = setup(&env);
-    let stranger = Address::generate(&env);
-    c.sync_balance(&stranger);
+    let contract_id = c.address.clone();
+
+    mint(&env, &token, &contract_id, 500);
+    c.sync_balance();
+    assert_eq!(c.get_state().balance, 500);
 }
 

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,30 @@
+# Bug fixes: CEI violation in refund-processor, permissionless sync_balance in treasury-manager
+
+## Summary
+
+- **refund-processor**: fixed a Checks-Effects-Interactions violation in `process_refund` where the token transfer was executed before the refund status was persisted to storage, opening a re-entrancy window.
+- **treasury-manager**: made `sync_balance` permissionless so any caller can reconcile the internal balance counter with the actual on-chain token balance (e.g. after a direct transfer to the contract address).
+- **governance-dao**: the cross-contract `invoke_contract` call in `execute_proposal` was already present — no code change required.
+- **whitelist-registry**: persistent TTL extension on individual whitelist entries was already in place for both `is_whitelisted` and `get_entry` — no code change required.
+
+## Changes
+
+### contracts/refund-processor/src/lib.rs
+Reordered `process_refund` to follow CEI strictly:
+1. Checks (status, deadline, balance)
+2. Effects (set `Processed`, persist refund, remove `PendingRefund`, extend TTL)
+3. Interaction (`token_client.transfer`)
+
+### contracts/treasury-manager/src/lib.rs
+Removed the `admin: Address` parameter and its auth / equality guards from `sync_balance`. The function now reads the live on-chain token balance and writes it to `state.balance` without any authorization requirement.
+
+### contracts/treasury-manager/src/test.rs
+- Updated `test_sync_balance` to call `sync_balance()` without an admin argument.
+- Replaced the now-irrelevant `test_sync_balance_unauthorized` test with `test_sync_balance_permissionless`, which verifies that a direct token mint to the contract address is correctly reflected after calling `sync_balance`.
+
+## Closes
+
+closes #552
+closes #549
+closes #551
+closes #550


### PR DESCRIPTION


## Summary

- **refund-processor**: fixed a Checks-Effects-Interactions violation in `process_refund` where the token transfer was executed before the refund status was persisted to storage, opening a re-entrancy window.
- **treasury-manager**: made `sync_balance` permissionless so any caller can reconcile the internal balance counter with the actual on-chain token balance (e.g. after a direct transfer to the contract address).
- **governance-dao**: the cross-contract `invoke_contract` call in `execute_proposal` was already present — no code change required.
- **whitelist-registry**: persistent TTL extension on individual whitelist entries was already in place for both `is_whitelisted` and `get_entry` — no code change required.

## Changes

### contracts/refund-processor/src/lib.rs
Reordered `process_refund` to follow CEI strictly:
1. Checks (status, deadline, balance)
2. Effects (set `Processed`, persist refund, remove `PendingRefund`, extend TTL)
3. Interaction (`token_client.transfer`)

### contracts/treasury-manager/src/lib.rs
Removed the `admin: Address` parameter and its auth / equality guards from `sync_balance`. The function now reads the live on-chain token balance and writes it to `state.balance` without any authorization requirement.

### contracts/treasury-manager/src/test.rs
- Updated `test_sync_balance` to call `sync_balance()` without an admin argument.
- Replaced the now-irrelevant `test_sync_balance_unauthorized` test with `test_sync_balance_permissionless`, which verifies that a direct token mint to the contract address is correctly reflected after calling `sync_balance`.

## Closes

closes #552
closes #549
closes #551
closes #550
