### PR TITLE
fix: resolve anomaly-detector and performance-oracle bugs (#613, #614, #616, #617)

### DIFF
--- a/contracts/anomaly-detector/src/lib.rs
+++ b/contracts/anomaly-detector/src/lib.rs
@@ -311,6 +311,14 @@ impl AnomalyDetectorContract {
 
         report.resolved = true;
         report.resolved_at = Some(env.ledger().timestamp());
+
+        // Clear the persistent publisher flag so the publisher is no longer blocked
+        if let Some(ref pub_addr) = report.publisher {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::FlaggedPublisher(pub_addr.clone()));
+        }
+
         let _ttl_key = DataKey::Report(report_id);
         env.storage().persistent().set(&_ttl_key, &report);
         env.storage().persistent().extend_ttl(

--- a/contracts/anomaly-detector/src/lib.rs
+++ b/contracts/anomaly-detector/src/lib.rs
@@ -305,6 +305,10 @@ impl AnomalyDetectorContract {
             .get(&DataKey::Report(report_id))
             .expect("report not found");
 
+        if report.resolved {
+            panic!("anomaly report is already resolved");
+        }
+
         report.resolved = true;
         report.resolved_at = Some(env.ledger().timestamp());
         let _ttl_key = DataKey::Report(report_id);

--- a/contracts/performance-oracle/src/lib.rs
+++ b/contracts/performance-oracle/src/lib.rs
@@ -125,6 +125,16 @@ impl PerformanceOracleContract {
             panic!("already attested");
         }
 
+        if quality_score > 100 {
+            panic!("quality_score must be 0-100");
+        }
+        if fraud_rate > 10_000 {
+            panic!("fraud_rate must be 0-10000 basis points");
+        }
+        if clicks > impressions {
+            panic!("clicks cannot exceed impressions");
+        }
+
         // Enforce hard cap on attesters to prevent exceeding Soroban CPU limits
         let count: u32 = env
             .storage()

--- a/contracts/performance-oracle/src/lib.rs
+++ b/contracts/performance-oracle/src/lib.rs
@@ -231,14 +231,6 @@ impl PerformanceOracleContract {
     }
 
     fn _try_build_consensus(env: &Env, campaign_id: u64, total_attesters: u32) {
-        if env
-            .storage()
-            .persistent()
-            .has(&DataKey::Consensus(campaign_id))
-        {
-            return;
-        }
-
         let min_attesters: u32 = env
             .storage()
             .instance()


### PR DESCRIPTION
## Summary

- **#613 (anomaly-detector):** `resolve_anomaly` now panics early if `report.resolved` is already `true`, preventing overwrite of the original `resolved_at` audit timestamp.
- **#614 (anomaly-detector):** `resolve_anomaly` now removes the `FlaggedPublisher` persistent key for the report's publisher, so `is_publisher_flagged` correctly returns `false` after an admin resolves the report.
- **#616 (performance-oracle):** `submit_attestation` now validates `quality_score <= 100`, `fraud_rate <= 10_000` basis points, and `clicks <= impressions` before storing, preventing corrupted consensus averages.
- **#617 (performance-oracle):** Removed the early-return guard in `_try_build_consensus` that froze consensus after the first `min_attesters` submitted. Consensus is now recomputed on every new attestation so `get_consensus` always reflects the latest data.

## Test plan

- [ ] Call `resolve_anomaly` on an already-resolved report — should panic with `"anomaly report is already resolved"`
- [ ] Resolve a Critical report for a publisher — `is_publisher_flagged` should return `false` afterwards
- [ ] Submit an attestation with `quality_score = 101` — should panic
- [ ] Submit an attestation with `fraud_rate = 10_001` — should panic
- [ ] Submit an attestation with `clicks > impressions` — should panic
- [ ] Submit additional attestations after consensus is first reached — `get_consensus` should reflect updated averages



closes #613 closes #614 closes #616 closes #617