### PR TITLE
fix: governance-token mint overflow and approve expiry validation (#6…

### DIFF
--- a/contracts/governance-token/src/lib.rs
+++ b/contracts/governance-token/src/lib.rs
@@ -319,6 +319,10 @@ impl GovernanceTokenContract {
             panic!("allowance amount must be non-negative");
         }
 
+        if expiry <= env.ledger().sequence() {
+            panic!("expiry must be a future ledger sequence");
+        }
+
         let _ttl_key = DataKey::Allowance(owner, spender);
         env.storage()
             .persistent()
@@ -359,7 +363,8 @@ impl GovernanceTokenContract {
             .get(&DataKey::TotalSupply)
             .unwrap_or(0);
 
-        if current_supply + amount > MAX_SUPPLY {
+        let new_supply = current_supply.checked_add(amount).expect("supply overflow");
+        if new_supply > MAX_SUPPLY {
             panic!("exceeds max supply");
         }
 

--- a/contracts/governance-token/src/test.rs
+++ b/contracts/governance-token/src/test.rs
@@ -191,3 +191,28 @@ fn test_balance_zero() {
     let (c, _) = setup(&env);
     assert_eq!(c.balance(&Address::generate(&env)), 0);
 }
+
+#[test]
+#[should_panic(expected = "expiry must be a future ledger sequence")]
+fn test_approve_expired_expiry_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    c.mint(&admin, &owner, &1_000i128);
+    // ledger sequence starts at 0; expiry=0 must be rejected
+    c.approve(&owner, &spender, &500i128, &0u32);
+}
+
+#[test]
+#[should_panic(expected = "supply overflow")]
+fn test_mint_supply_overflow_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, admin) = setup(&env);
+    let user = Address::generate(&env);
+    // i128::MAX + 1 overflows; checked_add must catch this
+    c.mint(&admin, &user, &i128::MAX);
+    c.mint(&admin, &user, &1i128);
+}


### PR DESCRIPTION
…44, #645)

- mint: replace raw i128 addition with checked_add to prevent silent overflow bypassing the MAX_SUPPLY cap guard (fixes closes #645)
- approve: reject expiry <= current ledger sequence so callers cannot create an allowance that is immediately expired (fixes closes #644)
- add regression tests for both new panic paths