### PR TITLE
Fix validation and cancellation guard rails

### DIFF
--- a/contracts/anomaly-detector/src/lib.rs
+++ b/contracts/anomaly-detector/src/lib.rs
@@ -113,6 +113,13 @@ impl AnomalyDetectorContract {
             panic!("unauthorized");
         }
 
+        if avg_impressions == 0 || avg_clicks == 0 {
+            panic!("baseline averages must be positive");
+        }
+        if spike_threshold < 100 {
+            panic!("spike_threshold must be at least 100");
+        }
+
         let baseline = TrafficBaseline {
             campaign_id,
             avg_impressions_per_hour: avg_impressions,
@@ -130,7 +137,13 @@ impl AnomalyDetectorContract {
         );
     }
 
-    pub fn update_baseline(env: Env, admin: Address, campaign_id: u64, new_impressions: u64, new_clicks: u64) {
+    pub fn update_baseline(
+        env: Env,
+        admin: Address,
+        campaign_id: u64,
+        new_impressions: u64,
+        new_clicks: u64,
+    ) {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
@@ -147,7 +160,9 @@ impl AnomalyDetectorContract {
             let max_impressions = baseline
                 .avg_impressions_per_hour
                 .saturating_mul(MAX_BASELINE_MULTIPLIER);
-            let max_clicks = baseline.avg_clicks_per_hour.saturating_mul(MAX_BASELINE_MULTIPLIER);
+            let max_clicks = baseline
+                .avg_clicks_per_hour
+                .saturating_mul(MAX_BASELINE_MULTIPLIER);
 
             if new_impressions > max_impressions {
                 panic!("baseline change too large");
@@ -158,7 +173,11 @@ impl AnomalyDetectorContract {
 
             env.events().publish(
                 (symbol_short!("baseline"), symbol_short!("updated")),
-                (campaign_id, baseline.avg_impressions_per_hour, new_impressions),
+                (
+                    campaign_id,
+                    baseline.avg_impressions_per_hour,
+                    new_impressions,
+                ),
             );
         }
 

--- a/contracts/campaign-orchestrator/src/lib.rs
+++ b/contracts/campaign-orchestrator/src/lib.rs
@@ -618,7 +618,7 @@ impl CampaignOrchestratorContract {
         );
     }
 
-    /// Cancel campaign and refund remaining budget (if refundable)
+    /// Cancel campaign and refund remaining budget when refundable
     pub fn cancel_campaign(env: Env, advertiser: Address, campaign_id: u64) {
         env.storage()
             .instance()
@@ -633,10 +633,6 @@ impl CampaignOrchestratorContract {
 
         if campaign.advertiser != advertiser {
             panic!("unauthorized");
-        }
-
-        if !campaign.refundable {
-            panic!("campaign not refundable");
         }
 
         let refund = campaign.remaining_budget;
@@ -669,7 +665,7 @@ impl CampaignOrchestratorContract {
             );
         }
 
-        if refund > 0 {
+        if campaign.refundable && refund > 0 {
             let token_addr: Address = env
                 .storage()
                 .instance()

--- a/contracts/performance-oracle/src/lib.rs
+++ b/contracts/performance-oracle/src/lib.rs
@@ -92,6 +92,20 @@ impl PerformanceOracleContract {
         );
     }
 
+    pub fn revoke_attester(env: Env, admin: Address, attester: Address) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+
+        let _ttl_key = DataKey::Attester(attester);
+        env.storage().persistent().remove(&_ttl_key);
+    }
+
     pub fn submit_attestation(
         env: Env,
         attester: Address,
@@ -301,9 +315,10 @@ impl PerformanceOracleContract {
         } else {
             0
         };
-        
+
         let quality_deviation_bps = if avg_quality_score > 0 {
-            ((max_quality_score - min_quality_score) as u64 * 10000 / avg_quality_score as u64) as u32
+            ((max_quality_score - min_quality_score) as u64 * 10000 / avg_quality_score as u64)
+                as u32
         } else {
             0
         };

--- a/contracts/publisher-verification/src/lib.rs
+++ b/contracts/publisher-verification/src/lib.rs
@@ -347,6 +347,10 @@ impl PublisherVerificationContract {
             _ => panic!("publisher not verified"),
         }
 
+        if earning < 0 {
+            panic!("earning per impression must be non-negative");
+        }
+
         pub_data.total_earnings += earning;
         pub_data.total_impressions += 1;
         pub_data.last_active = env.ledger().timestamp();


### PR DESCRIPTION
Closes #651
Closes #650
Closes #649
Closes #648

## Summary
- Reject negative publisher earnings in `record_impression`
- Add `revoke_attester` to performance-oracle
- Allow campaign cancellation for non-refundable campaigns without issuing a refund
- Reject zero-value baselines in anomaly-detector