### PR TITLE
fix(contracts): fix #632 accrual auth, #633 zero withdraw, #634 payout CEI, and #635 TTL bump

### DIFF
--- a/contracts/liquidity-pool/src/lib.rs
+++ b/contracts/liquidity-pool/src/lib.rs
@@ -160,6 +160,10 @@ impl LiquidityPoolContract {
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         provider.require_auth();
 
+        if shares <= 0 {
+            panic!("shares must be positive");
+        }
+
         let mut position: ProviderPosition = env
             .storage()
             .persistent()
@@ -295,16 +299,22 @@ impl LiquidityPoolContract {
     }
 
     /// Accrue interest on a borrow position
-    pub fn accrue_interest(env: Env, campaign_id: u64) -> i128 {
+    pub fn accrue_interest(env: Env, caller: Address, campaign_id: u64) -> i128 {
         env.storage()
             .instance()
             .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        caller.require_auth();
 
         let mut borrow: BorrowPosition = env
             .storage()
             .persistent()
             .get(&DataKey::Borrow(campaign_id))
             .expect("borrow not found");
+
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if caller != admin && caller != borrow.borrower {
+            panic!("unauthorized");
+        }
 
         let pool: PoolState = env.storage().instance().get(&DataKey::PoolState).unwrap();
 

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -303,7 +303,7 @@ fn test_repay_partial_amount() {
 }
 
 #[test]
-#[should_panic(expected = "no shares in pool")]
+#[should_panic(expected = "shares must be positive")]
 fn test_withdraw_when_total_shares_zero() {
     let env = Env::default();
     env.mock_all_auths();
@@ -316,6 +316,20 @@ fn test_withdraw_when_total_shares_zero() {
     c.withdraw(&provider, &shares);
 
     // Pool now has total_shares == 0; attempting to withdraw 0 shares must panic
+    c.withdraw(&provider, &0i128);
+}
+
+#[test]
+#[should_panic(expected = "shares must be positive")]
+fn test_withdraw_rejects_zero_shares() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _, _, token) = setup(&env);
+    let provider = Address::generate(&env);
+
+    mint(&env, &token, &provider, 1_000_000);
+    c.deposit(&provider, &100_000i128);
+
     c.withdraw(&provider, &0i128);
 }
 
@@ -339,7 +353,7 @@ fn test_borrow_utilization_rate_not_calculated_when_liquidity_zero() {
 fn test_accrue_interest() {
     let env = Env::default();
     env.mock_all_auths();
-    let (c, _, _, token) = setup(&env);
+    let (c, admin, _, token) = setup(&env);
     let provider = Address::generate(&env);
     let borrower = Address::generate(&env);
 
@@ -355,13 +369,30 @@ fn test_accrue_interest() {
     });
 
     // Accrue interest
-    let interest = c.accrue_interest(&1u64);
+    let interest = c.accrue_interest(&admin, &1u64);
 
     // At 5% annual rate on 100,000: interest should be ~5,000
     assert!(interest >= 4_900 && interest <= 5_100);
 
     let borrow = c.get_borrow(&1u64).unwrap();
     assert_eq!(borrow.interest_accrued, interest);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_accrue_interest_rejects_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (c, _, _, token) = setup(&env);
+    let provider = Address::generate(&env);
+    let borrower = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    mint(&env, &token, &provider, 1_000_000);
+    c.deposit(&provider, &500_000i128);
+    c.borrow(&borrower, &1u64, &100_000i128, &86_400u64);
+
+    c.accrue_interest(&stranger, &1u64);
 }
 
 #[test]
@@ -437,7 +468,7 @@ fn test_interest_calculation_over_time() {
         li.timestamp += 15_778_800; // ~6 months
     });
 
-    let interest_6mo = c.accrue_interest(&1u64);
+    let interest_6mo = c.accrue_interest(&borrower, &1u64);
     assert!(interest_6mo >= 2_400 && interest_6mo <= 2_600); // ~2.5% of 100k
 
     // Check interest after another 6 months (1 year total)
@@ -445,7 +476,7 @@ fn test_interest_calculation_over_time() {
         li.timestamp += 15_778_800;
     });
 
-    let interest_1yr = c.accrue_interest(&1u64);
+    let interest_1yr = c.accrue_interest(&borrower, &1u64);
     assert!(interest_1yr >= 4_900 && interest_1yr <= 5_100); // ~5% of 100k
 }
 

--- a/contracts/payout-automation/src/lib.rs
+++ b/contracts/payout-automation/src/lib.rs
@@ -205,13 +205,6 @@ impl PayoutAutomationContract {
             panic!("too early to execute");
         }
 
-        let token_client = token::Client::new(&env, &payout.token);
-        token_client.transfer(
-            &env.current_contract_address(),
-            &payout.recipient,
-            &payout.amount,
-        );
-
         payout.status = PayoutStatus::Completed;
         payout.executed_at = Some(env.ledger().timestamp());
         let _ttl_key = DataKey::Payout(payout_id);
@@ -246,6 +239,13 @@ impl PayoutAutomationContract {
             &key,
             PERSISTENT_LIFETIME_THRESHOLD,
             PERSISTENT_BUMP_AMOUNT,
+        );
+
+        let token_client = token::Client::new(&env, &payout.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &payout.recipient,
+            &payout.amount,
         );
 
         env.events().publish(
@@ -320,6 +320,9 @@ impl PayoutAutomationContract {
     }
 
     pub fn set_max_pending_amount(env: Env, admin: Address, amount: i128) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         admin.require_auth();
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {

--- a/contracts/payout-automation/src/test.rs
+++ b/contracts/payout-automation/src/test.rs
@@ -357,3 +357,14 @@ fn test_get_publisher_earnings_nonexistent_returns_none() {
 
     assert!(client.get_publisher_earnings(&unknown).is_none());
 }
+
+#[test]
+fn test_set_max_pending_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+
+    client.set_max_pending_amount(&admin, &2_000_000i128);
+
+    assert_eq!(client.get_max_pending_amount(), 2_000_000);
+}


### PR DESCRIPTION
Closes #632 
Closes #633 
Closes #634 
Closes #635 

# PR Description

Fixes #632, #633, #634, and #635 in the Soroban contracts. Liquidity pool withdrawals now reject zero or negative shares before any pool or position lookup/mutation, preventing silent zero-share withdrawals. Liquidity pool interest accrual now requires an authorized caller and only allows the pool admin or the original borrower to mutate the borrow position. Payout execution now follows checks-effects-interactions by persisting completed payout and earnings state before the token transfer, closing the stale-status reentrancy window. `set_max_pending_amount` now refreshes instance storage TTL like the rest of the payout automation mutators.

# Changed

- #633: Added positive share validation to `liquidity-pool::withdraw`.
- #632: Added caller authorization to `liquidity-pool::accrue_interest`.
- #634: Reordered `payout-automation::execute_payout` so state updates happen before token transfer.
- #635: Added instance TTL extension to `payout-automation::set_max_pending_amount`.
- Added focused regression tests for the fixed contract behavior.