### PR TITLE
Fix #630: resolve CEI violation in liquidity-pool deposit

### DIFF
--- a/contracts/liquidity-pool/src/lib.rs
+++ b/contracts/liquidity-pool/src/lib.rs
@@ -101,8 +101,8 @@ impl LiquidityPoolContract {
             .get(&DataKey::TokenAddress)
             .unwrap();
         let token_client = token::Client::new(&env, &token_addr);
-        token_client.transfer(&provider, &env.current_contract_address(), &amount);
 
+        // --- Effects: compute shares and commit all state before the external call ---
         let mut pool: PoolState = env.storage().instance().get(&DataKey::PoolState).unwrap();
         let total_shares: i128 = env
             .storage()
@@ -124,10 +124,11 @@ impl LiquidityPoolContract {
             .instance()
             .set(&DataKey::TotalShares, &(total_shares + shares));
 
+        let provider_key = DataKey::Provider(provider.clone());
         let mut position: ProviderPosition = env
             .storage()
             .persistent()
-            .get(&DataKey::Provider(provider.clone()))
+            .get(&provider_key)
             .unwrap_or(ProviderPosition {
                 provider: provider.clone(),
                 deposited: 0,
@@ -138,13 +139,15 @@ impl LiquidityPoolContract {
 
         position.deposited += amount;
         position.shares += shares;
-        let _ttl_key = DataKey::Provider(provider.clone());
-        env.storage().persistent().set(&_ttl_key, &position);
+        env.storage().persistent().set(&provider_key, &position);
         env.storage().persistent().extend_ttl(
-            &_ttl_key,
+            &provider_key,
             PERSISTENT_LIFETIME_THRESHOLD,
             PERSISTENT_BUMP_AMOUNT,
         );
+
+        // --- Interaction: pull tokens from provider after all state is committed ---
+        token_client.transfer(&provider, &env.current_contract_address(), &amount);
 
         env.events().publish(
             (symbol_short!("pool"), symbol_short!("deposit")),


### PR DESCRIPTION
Incoming token transfer was executed before pool.total_liquidity, TotalShares, and ProviderPosition were updated. Any re-entrant callback during the transfer would observe stale pool state and could mint inflated shares against the unchanged liquidity figures.

Reorder to strict Checks-Effects-Interactions:
1. Checks     – auth + amount validation (unchanged)
2. Effects    – share computation, pool state, TotalShares, and provider
               position are all written to storage first
3. Interaction – token_client.transfer is the last operation

Also rename _ttl_key to provider_key; the single DataKey allocation is now reused across the get/set/extend_ttl calls, eliminating the redundant clone that the old intermediate variable required.

Closes #630