### PR TITLE
fix: only refund dispute filing fee on favorable outcomes

### DIFF
--- a/contracts/dispute-resolution/src/lib.rs
+++ b/contracts/dispute-resolution/src/lib.rs
@@ -309,7 +309,11 @@ impl DisputeResolutionContract {
             .instance()
             .get(&DataKey::FilingFee)
             .unwrap_or(0);
-        if fee > 0 {
+        let fee_to_claimant = matches!(
+            outcome,
+            DisputeOutcome::Claimant | DisputeOutcome::Split | DisputeOutcome::NoAction
+        );
+        if fee > 0 && fee_to_claimant {
             let token_client = token::Client::new(&env, &dispute.token);
             token_client.transfer(&env.current_contract_address(), &dispute.claimant, &fee);
         }

--- a/contracts/dispute-resolution/src/test.rs
+++ b/contracts/dispute-resolution/src/test.rs
@@ -378,12 +378,15 @@ fn test_resolve_dispute_respondent_does_not_receive_filing_fee() {
         &String::from_str(&env, "respondent wins"),
     );
 
-    assert_eq!(token_client.balance(&claimant), initial_claimant_balance - 50_000);
+    assert_eq!(
+        token_client.balance(&claimant),
+        initial_claimant_balance - 50_000 - 1_000
+    );
     assert_eq!(
         token_client.balance(&respondent),
         initial_respondent_balance + 50_000
     );
-    assert_eq!(token_client.balance(&client.address), 0);
+    assert_eq!(token_client.balance(&client.address), 1_000);
 }
 
 #[test]


### PR DESCRIPTION
## 📌 Summary
Fix dispute-resolution filing fee handling so the fee is only refunded to the claimant when the outcome favors them, not on every resolution.

## 🎯 Purpose / Motivation
`resolve_dispute` unconditionally returned the filing fee to the claimant for every outcome, including `Respondent` (claimant lost). That removed any economic deterrent against frivolous or bad-faith disputes, since the fee was always refunded regardless of merit.

## 🛠️ Changes Made
- #681: Gate filing fee refund on favorable outcomes (`Claimant`, `Split`, `NoAction`) in `resolve_dispute`.
- On `Respondent` outcome, the filing fee remains in the contract as protocol revenue instead of being returned to the claimant.
- Updated `test_resolve_dispute_respondent_does_not_receive_filing_fee` to assert the claimant forfeits the fee and the contract retains it.

## 🧪 How to Test
1. Run dispute-resolution tests:
   ```bash
   cd contracts && cargo test -p pulsar-dispute-resolution resolve_dispute
   ```
2. **Respondent outcome (claimant loses):**
   - File a dispute with a non-zero filing fee.
   - Resolve with `DisputeOutcome::Respondent`.
   - **Expected:** Claim amount goes to respondent; filing fee stays in the contract; claimant does not receive the fee back.
3. **Claimant / Split / NoAction outcomes:**
   - Resolve disputes with each favorable outcome.
   - **Expected:** Filing fee is refunded to the claimant (along with any claim settlement per existing logic).
4. **Edge case — zero filing fee:**
   - Initialize with `filing_fee = 0` and resolve with any outcome.
   - **Expected:** No fee transfer; existing settlement behavior unchanged.

## 📸 Screenshots (if applicable)
N/A — contract logic only.

## ⚠️ Breaking Changes
- None for callers, but economic behavior changes: claimants who lose (`Respondent` outcome) no longer receive an automatic filing fee refund.

## 🔗 Related Issues
Closes ThinkLikeAFounder/pulsartrack#681

## ✅ Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)
