### PR TITLE
fix: reject self-disputes in file_dispute

### DIFF
--- a/contracts/dispute-resolution/src/lib.rs
+++ b/contracts/dispute-resolution/src/lib.rs
@@ -125,6 +125,9 @@ impl DisputeResolutionContract {
         if claim_amount <= 0 {
             panic!("invalid claim amount");
         }
+        if claimant == respondent {
+            panic!("claimant and respondent cannot be the same address");
+        }
 
         // Collect filing fee
         let fee: i128 = env

--- a/contracts/dispute-resolution/src/test.rs
+++ b/contracts/dispute-resolution/src/test.rs
@@ -155,6 +155,26 @@ fn test_file_dispute() {
 }
 
 #[test]
+#[should_panic(expected = "claimant and respondent cannot be the same address")]
+fn test_file_dispute_self_dispute_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, token_addr) = setup(&env);
+
+    let claimant = Address::generate(&env);
+    mint(&env, &token_addr, &claimant, 1_000_000);
+
+    client.file_dispute(
+        &claimant,
+        &claimant,
+        &1u64,
+        &50_000i128,
+        &make_desc(&env),
+        &make_evidence(&env),
+    );
+}
+
+#[test]
 fn test_file_multiple_disputes() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary
Prevents self-disputes in the dispute-resolution contract by rejecting `file_dispute` calls where the claimant and respondent are the same address.

## Purpose / Motivation
Without this guard, an account could file a dispute against itself, locking its own `claim_amount + filing fee` in the contract with no real counterparty. That enables griefing (tying up dispute slots) and, if combined with a compromised arbitrator, could be abused to extract locked funds.

## Changes Made
- Add an early validation in `file_dispute` that panics when `claimant == respondent`, before any token transfers occur.
- Add `test_file_dispute_self_dispute_fails` to verify self-disputes are rejected and no funds are locked.

## How to Test
1. From the repo root, run dispute-resolution contract tests:
   ```bash
   cargo test -p dispute-resolution
   ```
2. Confirm `test_file_dispute_self_dispute_fails` passes (expects panic with `"claimant and respondent cannot be the same address"`).
3. Confirm existing `test_file_dispute` and `test_file_multiple_disputes` still pass with distinct claimant/respondent addresses.

## Breaking Changes
- None for valid callers. Any integration that previously allowed self-disputes will now revert at submission time.

## Related Issues
Closes ThinkLikeAFounder/pulsartrack#682

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)
