### PR TITLE
fix(dispute-resolution): add revoke_arbitrator for compromised arbitrators

### DIFF
--- a/contracts/dispute-resolution/README.md
+++ b/contracts/dispute-resolution/README.md
@@ -44,6 +44,11 @@ Sets the contract configuration. Can only be called once.
 Adds an address to the approved arbitrator pool.
 - **Restrictions**: Admin only (`require_auth()`).
 
+#### `revoke_arbitrator(admin: Address, arbitrator: Address)`
+Removes an address from the approved arbitrator pool by deleting its persistent authorization key.
+- **Restrictions**: Admin only (`require_auth()`).
+- **Effect**: Revoked arbitrators cannot be assigned to new disputes; already-assigned disputes are unchanged.
+
 #### `assign_arbitrator(admin: Address, dispute_id: u64, arbitrator: Address)`
 Assigns an approved arbitrator to an active dispute.
 - **Restrictions**: Admin only. The arbitrator must be previously authorized.

--- a/contracts/dispute-resolution/src/lib.rs
+++ b/contracts/dispute-resolution/src/lib.rs
@@ -109,6 +109,20 @@ impl DisputeResolutionContract {
         );
     }
 
+    pub fn revoke_arbitrator(env: Env, admin: Address, arbitrator: Address) {
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ArbitratorApproved(arbitrator));
+    }
+
     pub fn file_dispute(
         env: Env,
         claimant: Address,

--- a/contracts/dispute-resolution/src/test.rs
+++ b/contracts/dispute-resolution/src/test.rs
@@ -120,6 +120,57 @@ fn test_authorize_arbitrator_by_stranger() {
     client.authorize_arbitrator(&stranger, &arbitrator);
 }
 
+// ─── revoke_arbitrator ───────────────────────────────────────────────────────
+
+#[test]
+fn test_revoke_arbitrator() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+    let arbitrator = Address::generate(&env);
+
+    client.authorize_arbitrator(&admin, &arbitrator);
+    client.revoke_arbitrator(&admin, &arbitrator);
+}
+
+#[test]
+#[should_panic(expected = "arbitrator not authorized")]
+fn test_revoke_arbitrator_blocks_assignment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, token_addr) = setup(&env);
+
+    let claimant = Address::generate(&env);
+    let respondent = Address::generate(&env);
+    let arbitrator = Address::generate(&env);
+    mint(&env, &token_addr, &claimant, 1_000_000);
+
+    let dispute_id = client.file_dispute(
+        &claimant,
+        &respondent,
+        &1u64,
+        &50_000i128,
+        &make_desc(&env),
+        &make_evidence(&env),
+    );
+
+    client.authorize_arbitrator(&admin, &arbitrator);
+    client.revoke_arbitrator(&admin, &arbitrator);
+    client.assign_arbitrator(&admin, &dispute_id, &arbitrator);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_revoke_arbitrator_by_stranger() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _) = setup(&env);
+    let stranger = Address::generate(&env);
+    let arbitrator = Address::generate(&env);
+
+    client.revoke_arbitrator(&stranger, &arbitrator);
+}
+
 // ─── file_dispute ────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Adds `revoke_arbitrator` to the dispute-resolution Soroban contract so admins can immediately remove compromised or misbehaving arbitrators from the approved pool.

## Purpose / Motivation
`authorize_arbitrator` persisted `ArbitratorApproved` keys with a long TTL (~61 days), but there was no symmetric revocation path. A bad arbitrator stayed eligible for new dispute assignments until storage expired naturally. This closes that operational gap.

## Changes Made
- Added `revoke_arbitrator(env, admin, arbitrator)` mirroring `authorize_arbitrator` auth checks and removing `DataKey::ArbitratorApproved(arbitrator)` from persistent storage.
- Added unit tests: successful revoke, post-revoke assignment rejection, and stranger unauthorized revoke.
- Documented the new function in `contracts/dispute-resolution/README.md`.

## How to Test
1. From the repo root (or this worktree), run:
   ```bash
   cargo test -p pulsar-dispute-resolution
   ```
2. Confirm `test_revoke_arbitrator`, `test_revoke_arbitrator_blocks_assignment`, and `test_revoke_arbitrator_by_stranger` pass.
3. Manually (optional on testnet): call `authorize_arbitrator`, then `revoke_arbitrator`, then `assign_arbitrator` for the same address — assignment should fail with `arbitrator not authorized`.

## Breaking Changes
- None. New admin-only function; existing disputes with an already-assigned arbitrator are unaffected.

## Related Issues
Closes ThinkLikeAFounder/pulsartrack#684

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)
