### PR TITLE
fix: guard assign_arbitrator against finalized disputes

### DIFF
--- a/contracts/dispute-resolution/src/lib.rs
+++ b/contracts/dispute-resolution/src/lib.rs
@@ -214,6 +214,10 @@ impl DisputeResolutionContract {
             .get(&DataKey::Dispute(dispute_id))
             .expect("dispute not found");
 
+        if dispute.status == DisputeStatus::Resolved || dispute.status == DisputeStatus::Closed {
+            panic!("cannot assign arbitrator to a finalized dispute");
+        }
+
         dispute.arbitrator = Some(arbitrator);
         dispute.status = DisputeStatus::UnderReview;
         let _ttl_key = DataKey::Dispute(dispute_id);

--- a/contracts/dispute-resolution/src/test.rs
+++ b/contracts/dispute-resolution/src/test.rs
@@ -265,6 +265,40 @@ fn test_assign_unauthorized_arbitrator() {
     client.assign_arbitrator(&admin, &dispute_id, &arbitrator);
 }
 
+#[test]
+#[should_panic(expected = "cannot assign arbitrator to a finalized dispute")]
+fn test_assign_arbitrator_on_resolved_dispute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, token_addr) = setup(&env);
+
+    let claimant = Address::generate(&env);
+    let respondent = Address::generate(&env);
+    let arbitrator = Address::generate(&env);
+    let new_arbitrator = Address::generate(&env);
+    mint(&env, &token_addr, &claimant, 1_000_000);
+
+    let dispute_id = client.file_dispute(
+        &claimant,
+        &respondent,
+        &1u64,
+        &50_000i128,
+        &make_desc(&env),
+        &make_evidence(&env),
+    );
+    client.authorize_arbitrator(&admin, &arbitrator);
+    client.authorize_arbitrator(&admin, &new_arbitrator);
+    client.assign_arbitrator(&admin, &dispute_id, &arbitrator);
+    client.resolve_dispute(
+        &arbitrator,
+        &dispute_id,
+        &DisputeOutcome::Claimant,
+        &String::from_str(&env, "claimant wins"),
+    );
+
+    client.assign_arbitrator(&admin, &dispute_id, &new_arbitrator);
+}
+
 // ─── resolve_dispute ─────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Adds a status guard to `assign_arbitrator` so finalized disputes cannot be reopened by reassigning an arbitrator.

## Purpose / Motivation
`assign_arbitrator` previously overwrote `dispute.arbitrator` and set `dispute.status = UnderReview` with no check on the current status. An admin could call it on a `Resolved` dispute, reverting its status and allowing a new arbitrator to call `resolve_dispute` again — effectively redistributing funds a second time.

## Changes Made
- Guard `assign_arbitrator` against `Resolved` and `Closed` disputes with panic message `"cannot assign arbitrator to a finalized dispute"`.
- Add `test_assign_arbitrator_on_resolved_dispute` to verify reassignment fails after resolution.

## How to Test
1. File a dispute, authorize and assign an arbitrator, then resolve the dispute.
2. Attempt to call `assign_arbitrator` again with a different authorized arbitrator.
3. Confirm the call panics with `"cannot assign arbitrator to a finalized dispute"`.
4. Confirm the dispute status remains `Resolved` and the original arbitrator is unchanged.

Run contract tests:
```bash
cargo test -p dispute-resolution
```

## Breaking Changes
None. Admin reassignment on finalized disputes was unintended behavior.

## Related Issues
Closes ThinkLikeAFounder/pulsartrack#683

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)
