### PR TITLE
fix: escrow-vault refund restriction, cancel_admin_proposal, saturating_sub for DelegatedPower

### DIFF
--- a/contracts/common-admin/src/lib.rs
+++ b/contracts/common-admin/src/lib.rs
@@ -1,6 +1,22 @@
 #![no_std]
 use soroban_sdk::{Address, Env, IntoVal, TryFromVal, Val};
 
+pub fn cancel_admin_proposal<K>(env: &Env, admin_key: &K, pending_key: &K, current_admin: Address)
+where
+    K: IntoVal<Env, Val> + TryFromVal<Env, Val> + Clone,
+{
+    current_admin.require_auth();
+    let stored: Address = env
+        .storage()
+        .instance()
+        .get(admin_key)
+        .expect("not initialized");
+    if current_admin != stored {
+        panic!("unauthorized");
+    }
+    env.storage().instance().remove(pending_key);
+}
+
 pub fn propose_admin<K>(
     env: &Env,
     admin_key: &K,

--- a/contracts/escrow-vault/src/lib.rs
+++ b/contracts/escrow-vault/src/lib.rs
@@ -472,6 +472,11 @@ impl EscrowVaultContract {
             .get(&DataKey::Escrow(escrow_id))
             .expect("escrow not found");
 
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if caller != escrow.depositor && caller != admin {
+            panic!("only the depositor or admin can trigger a refund");
+        }
+
         let now = env.ledger().timestamp();
         if now < escrow.expires_at {
             panic!("escrow not yet expired");
@@ -770,6 +775,10 @@ impl EscrowVaultContract {
 
     pub fn accept_admin(env: Env, new_admin: Address) {
         pulsar_common_admin::accept_admin(&env, &DataKey::Admin, &DataKey::PendingAdmin, new_admin);
+    }
+
+    pub fn cancel_admin_proposal(env: Env, current_admin: Address) {
+        pulsar_common_admin::cancel_admin_proposal(&env, &DataKey::Admin, &DataKey::PendingAdmin, current_admin);
     }
 }
 

--- a/contracts/governance-token/src/lib.rs
+++ b/contracts/governance-token/src/lib.rs
@@ -502,7 +502,7 @@ impl GovernanceTokenContract {
             let _ttl_key = DataKey::DelegatedPower(delegation.delegate);
             env.storage()
                 .persistent()
-                .set(&_ttl_key, &(delegate_power - amount));
+                .set(&_ttl_key, &delegate_power.saturating_sub(amount));
             env.storage().persistent().extend_ttl(
                 &_ttl_key,
                 PERSISTENT_LIFETIME_THRESHOLD,
@@ -548,7 +548,7 @@ impl GovernanceTokenContract {
                 .persistent()
                 .get(&DataKey::DelegatedPower(old_delegation.delegate.clone()))
                 .unwrap_or(0);
-            let new_old_power = old_delegate_power - delegator_balance;
+            let new_old_power = old_delegate_power.saturating_sub(delegator_balance);
             let _ttl_key = DataKey::DelegatedPower(old_delegation.delegate);
             env.storage()
                 .persistent()
@@ -616,7 +616,7 @@ impl GovernanceTokenContract {
                 .persistent()
                 .get(&DataKey::DelegatedPower(delegation_info.delegate.clone()))
                 .unwrap_or(0);
-            let new_power = delegate_power - delegator_balance;
+            let new_power = delegate_power.saturating_sub(delegator_balance);
             let _ttl_key = DataKey::DelegatedPower(delegation_info.delegate);
             env.storage()
                 .persistent()
@@ -682,6 +682,10 @@ impl GovernanceTokenContract {
 
     pub fn accept_admin(env: Env, new_admin: Address) {
         pulsar_common_admin::accept_admin(&env, &DataKey::Admin, &DataKey::PendingAdmin, new_admin);
+    }
+
+    pub fn cancel_admin_proposal(env: Env, current_admin: Address) {
+        pulsar_common_admin::cancel_admin_proposal(&env, &DataKey::Admin, &DataKey::PendingAdmin, current_admin);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes three security/correctness bugs in one commit.

### #693 — escrow-vault: refund_escrow has no caller restriction
Added a check so only the depositor or admin can trigger a refund on an expired escrow. Previously any authenticated address could force-refund any expired escrow.

### #694 — common-admin: no cancel_admin_proposal function
Added `cancel_admin_proposal` to `common-admin` and exposed it on both `governance-token` and `escrow-vault`. The current admin can now revoke a pending admin transfer before the 17,280-ledger delay elapses.

### #708 — governance-token: raw subtraction on DelegatedPower
Replaced raw `-` with `saturating_sub` in all three places that decrement `DelegatedPower`:
- `burn`
- `delegate` (re-delegation path)
- `revoke_delegation`

Closes #693
Closes #694
Closes #708