### PR TITLE
fix: resolve contract security bugs #689 #690 #691 #692 and workflow issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
       - name: Build contracts
         run: cargo build --workspace
       - name: Run contract tests

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     name: Deploy Contracts
@@ -17,9 +20,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install Stellar CLI
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          cargo install --locked stellar-cli --features opt
+        run: cargo install --locked stellar-cli --features opt
 
       - name: Build contract WASMs
         run: cargo build --release --target wasm32-unknown-unknown

--- a/contracts/common-admin/src/lib.rs
+++ b/contracts/common-admin/src/lib.rs
@@ -19,6 +19,9 @@ pub fn propose_admin<K>(
     if current_admin != stored {
         panic!("unauthorized");
     }
+    if env.storage().instance().has(pending_key) {
+        panic!("pending admin proposal already exists");
+    }
     env.storage().instance().set(pending_key, &(new_admin, env.ledger().sequence()));
 }
 

--- a/contracts/dispute-resolution/src/lib.rs
+++ b/contracts/dispute-resolution/src/lib.rs
@@ -271,8 +271,11 @@ impl DisputeResolutionContract {
             panic!("not assigned arbitrator");
         }
 
-        if dispute.status == DisputeStatus::Resolved {
-            panic!("already resolved");
+        match dispute.status {
+            DisputeStatus::Resolved | DisputeStatus::Closed | DisputeStatus::Appealed => {
+                panic!("dispute cannot be resolved in its current status");
+            }
+            _ => {}
         }
 
         let (claimant_amount, respondent_amount) = match &outcome {

--- a/contracts/escrow-vault/src/lib.rs
+++ b/contracts/escrow-vault/src/lib.rs
@@ -78,6 +78,7 @@ pub enum DataKey {
     Escrow(u64),
     Approval(u64, Address),
     ApprovalCount(u64),
+    RequiredApproverCount(u64),
     RequiredApprover(u64, Address),
     Performance(u64),
 }
@@ -267,6 +268,15 @@ impl EscrowVaultContract {
                 PERSISTENT_BUMP_AMOUNT,
             );
         }
+
+        let required_count = required_approvers.len() as u32;
+        let _ttl_key = DataKey::RequiredApproverCount(escrow_id);
+        env.storage().persistent().set(&_ttl_key, &required_count);
+        env.storage().persistent().extend_ttl(
+            &_ttl_key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
 
         env.storage()
             .instance()
@@ -692,17 +702,17 @@ impl EscrowVaultContract {
         {
             let now = env.ledger().timestamp();
             let time_ok = now >= escrow.time_lock_until;
-            let min_threshold: u32 = env
+            let required_count: u32 = env
                 .storage()
-                .instance()
-                .get(&DataKey::MinApprovalThreshold)
-                .unwrap_or(1);
+                .persistent()
+                .get(&DataKey::RequiredApproverCount(escrow_id))
+                .unwrap_or(0);
             let approvals: u32 = env
                 .storage()
                 .persistent()
                 .get(&DataKey::ApprovalCount(escrow_id))
                 .unwrap_or(0);
-            let approvals_ok = approvals >= min_threshold;
+            let approvals_ok = approvals >= required_count;
 
             let perf_ok = if let Some(perf) = env
                 .storage()
@@ -733,17 +743,17 @@ impl EscrowVaultContract {
             panic!("time lock active");
         }
 
-        let min_threshold: u32 = env
+        let required_count: u32 = env
             .storage()
-            .instance()
-            .get(&DataKey::MinApprovalThreshold)
-            .unwrap_or(1);
+            .persistent()
+            .get(&DataKey::RequiredApproverCount(escrow_id))
+            .unwrap_or(0);
         let approvals: u32 = env
             .storage()
             .persistent()
             .get(&DataKey::ApprovalCount(escrow_id))
             .unwrap_or(0);
-        if approvals < min_threshold {
+        if approvals < required_count {
             panic!("approval required");
         }
 

--- a/contracts/rewards-distributor/src/lib.rs
+++ b/contracts/rewards-distributor/src/lib.rs
@@ -223,8 +223,8 @@ impl RewardsDistributorContract {
         let key = DataKey::UserRewards(user.clone());
         let mut rewards: UserRewards = env.storage().persistent().get(&key).expect("no rewards");
 
-        if rewards.total_earned <= 0 {
-            panic!("no available rewards");
+        if rewards.pending <= 0 {
+            panic!("no pending rewards to claim");
         }
 
         // Calculate vested amount based on linear vesting schedule


### PR DESCRIPTION
## Summary

Fixes four contract security/logic bugs and two CI/deploy workflow issues.

---

### #691 — dispute-resolution: resolve_dispute bypasses appeal process

**Root cause:** Guard only blocked `Resolved` status.  
**Fix:** Extended to a `match` that also blocks `Appealed` and `Closed`, preventing an arbitrator from unilaterally terminating a legitimately contested dispute.

### #692 — rewards-distributor: claim_rewards guard checks wrong field

**Root cause:** Guard checked `total_earned <= 0`, which is cumulative and never decremented, so fully-claimed users passed the check and hit an obscure downstream panic.  
**Fix:** Guard now checks `pending <= 0` — the field that actually reflects unclaimed rewards.

### #690 — common-admin: propose_admin silently overwrites pending proposal

**Root cause:** No existence check before writing the pending proposal.  
**Fix:** Added `if env.storage().instance().has(pending_key)` guard that panics with a clear message, preventing silent overwrites of a pending admin.

### #689 — escrow-vault: approve_release checks count, not all required approvers

**Root cause:** `_check_can_release` and `can_release` compared `approvals >= min_threshold` (a global config value), not the number of required approvers registered for that specific escrow.  
**Fix:** Added `RequiredApproverCount(u64)` to `DataKey`, stored at `create_escrow` time. Both check functions now compare `approvals >= required_count`, ensuring every registered required approver must sign off.

---

### Workflow fixes

- **CI:** Added `targets: wasm32-unknown-unknown` to the contracts job — without it, `cargo build --workspace` fails for Soroban contracts.
- **Deploy:** Removed the redundant `rustup` install step (conflicts with `dtolnay/rust-toolchain`); added `permissions: contents: write` so the deployment records commit/push step has the required permission.

---

Closes #689  
Closes #690  
Closes #691  
Closes #692